### PR TITLE
优化医学影像加载性能、升级临床界面并补充部署文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,130 +1,1050 @@
+# BrainU
 
-![logo.png](designSystem%2FBrainU-backend%2Fimg%2Flogo.png)
+![BrainU Logo](designSystem/BrainU-backend/img/logo.png)
 
+BrainU 是一个面向脑部 MRI 的肿瘤分割与医学影像浏览平台。系统由 Vue 2 临床工作台、Spring Boot 聚合服务、Python/PyTorch 推理服务以及 MySQL、Redis、MinIO 等基础设施组成，支持病例管理、MRI 文件上传、模型选择、肿瘤分割、三向切片浏览和结果下载。
 
-# brainU
-## 项目介绍
+> [!WARNING]
+> 本项目目前属于教学、科研和工程验证性质，不是经过医疗器械认证的诊断系统，不能直接用于临床诊断或治疗决策。
 
-基于多模态UNet神经网络+Pytorch+opencv+SpringBoot+Vue2的脑肿瘤自动分割web平台项目。用户可以针对某个病人的脑肿瘤核磁共振扫描的文件上传平台进行肿瘤分割。
+> [!CAUTION]
+> 仓库历史配置中存在数据库、Redis、MinIO 地址及凭据硬编码。公开部署前必须轮换相关凭据，并使用本地配置文件或环境变量覆盖，禁止继续使用仓库中出现过的任何密码。
 
-## 模型训练
-### Multi-modal U-Net 
-![mmunet.png](designSystem%2FBrainU-backend%2Fimg%2Fmmunet.png)
-#### 复现
-##### 模型参数结构表
-![paaramtable.png](designSystem%2FBrainU-backend%2Fimg%2Fpaaramtable.png)
-![table2.png](designSystem%2FBrainU-backend%2Fimg%2Ftable2.png)
-![table3.png](designSystem%2FBrainU-backend%2Fimg%2Ftable3.png)
+## 目录
 
-##### 训练环境
-![env.png](designSystem%2FBrainU-backend%2Fimg%2Fenv.png)
-![env2.png](designSystem%2FBrainU-backend%2Fimg%2Fenv2.png)
+- [功能概览](#功能概览)
+- [技术栈](#技术栈)
+- [项目结构](#项目结构)
+- [运行架构](#运行架构)
+- [部署方式选择](#部署方式选择)
+- [部署前必须确认的事项](#部署前必须确认的事项)
+- [本地开发环境搭建](#本地开发环境搭建)
+- [生产环境部署](#生产环境部署)
+- [微服务版本说明](#微服务版本说明)
+- [日常更新与回滚](#日常更新与回滚)
+- [常见问题](#常见问题)
+- [模型与实验结果](#模型与实验结果)
 
-##### 神经网络结构参数
-![unetparams.png](designSystem%2FBrainU-backend%2Fimg%2Funetparams.png)
-- batch_size:指定每次训练时使用的样本数。较大的 batch_size 能够提高训练速度，
-但可能会降低模型的准确性。
-- epoch: 指定训练的轮数。每一轮训练都会使用全部的训练数据，这有助于模型逐渐
-提高准确性，但如果训练轮数过多，可能会导致过拟合。
-- patience: 指定在验证集上连续多少个 epoch 的性能没有提升时，停止训练。这可以
-避免过拟合和浪费时间和计算资源。
-- learning rate drop: 当模型训练到一定程度时，为了避免过拟合和提高准确性，我
-们可以降低学习率。此超参数可以指定学习率下降的速度和幅度。
-- early stop: 当模型在验证集上的性能不再提升时，可以提前停止训练以节省时间和
-计算资源。此超参数可以指定在多少个 epoch 没有提升时，停止训练。
-- initial learning rate: 指定模型最初的学习率。较高的学习率可以提高训练速度，
-但可能会导致模型不稳定和性能下降，本次训练使用 Adam 自适应学习率算法，所以算法
-将根据损失函数的变化情况自动调整学习率的大小。
+## 功能概览
 
-##### 实验结果
-- Multi-modal U-Net脑部胶质瘤分割示例，从左到右分别为磁共振成像液体衰减反转序
-  列、T1 加权成像、T1c造影剂成像、T2 加权成像、模型预测的肿瘤掩模图以及真实的肿瘤掩模图
-![result.png](designSystem%2FBrainU-backend%2Fimg%2Fresult.png)
-
-- IoU 测量每个类别的预测标签和
-  地面实况标签之间的重叠。发现标签 0 的 IoU 为 99.6%，表明该模型准确地识别了此类。
-  标签 1、2 和 3 的 IoU 值也相对较高，分别为 78.4%、83.9%和 75%。这表明该模型能够准
-  确识别这些类，尽管还有一些改进的空间。另一方面，发现标签 4 的 IoU 为 87.2%，表明
-  该模型能够准确识别这一类别。
-
-![result1.png](designSystem%2FBrainU-backend%2Fimg%2Fresult1.png)
-
-
-
-## 架构图
-![system.png](designSystem%2FBrainU-backend%2Fimg%2Fsystem.png)
-
-## 流程图
-![process.png](designSystem%2FBrainU-backend%2Fimg%2Fprocess.png)
-
-## 模块设计图
-![design.png](designSystem%2FBrainU-backend%2Fimg%2Fdesign.png)
-
-## 系统用例图
-![use.png](designSystem%2FBrainU-backend%2Fimg%2Fuse.png)
-
-## 时序图
-### 肿瘤分割
-![timep.png](designSystem%2FBrainU-backend%2Fimg%2Ftimep.png)
-
-
-## 项目亮点
-
-1. **成功复现UNet和muti-modal UNet网络：**
-   - 基于PyTorch框架，成功复现了UNet和muti-modal UNet网络，并利用2015年脑肿瘤分割大赛的数据集进行训练。
-   - 对数据集进行了有效的预处理，并划分为训练集和测试集，在实测中达到了95%的准确率。
-
-2. **前后端交互实现在线脑肿瘤分割：**
-   - 借助Spring Boot和Vue框架，实现了系统的后端和前端交互。
-   - 调用自己开发的脑肿瘤分割接口，实现了在线脑肿瘤分割，为用户提供了便捷的服务。
-
-3. **数据可靠存储和高效管理：**
-   - 使用Minio进行数据的可靠存储和高效管理，将用户上传的脑部MRI影像保存到Minio中，保证了数据的安全性和可靠性。
-
-4. **引入评分机制实现模型的可迭代性：**
-   - 引入评分机制，用户可以对本次分割的精准度进行评分。
-   - 如果分数高于阈值，将本次训练参数保存到模型文件中，实现了模型的自我训练和迭代优化。
-
-
-
-## 截图
-### 登录
-![login.png](designSystem%2FBrainU-backend%2Fimg%2Flogin.png)
-### 数据添加
-![add.png](designSystem%2FBrainU-backend%2Fimg%2Fadd.png)
-![add2.png](designSystem%2FBrainU-backend%2Fimg%2Fadd2.png)
-### 工作空间
-![p1.png](designSystem%2FBrainU-backend%2Fimg%2Fp1.png)
-![p2.png](designSystem%2FBrainU-backend%2Fimg%2Fp2.png)
-### 肿瘤交互
-![tumor.png](designSystem%2FBrainU-backend%2Fimg%2Ftumor.png)
-### 模型管理
-![model.png](designSystem%2FBrainU-backend%2Fimg%2Fmodel.png)
-### 医生管理
-![doctor.png](designSystem%2FBrainU-backend%2Fimg%2Fdoctor.png)
+- 医生账号登录与基于 JWT、Redis 的会话校验。
+- 患者资料、待诊断病例和已诊断病例管理。
+- 批量上传 `.mha` MRI 序列及患者资料。
+- 选择 U-Net 或 Multi-modal U-Net 模型执行分割。
+- 将分割结果和原始切片上传至 MinIO。
+- 轴位、矢状位、冠状位和三维定位视图联动浏览。
+- 当前切片按需加载，并预取相邻切片，避免一次性加载数百张图像。
+- 原始影像与分割结果切换、当前切片下载、结果文件下载。
+- 模型信息、医生信息和诊断通知管理。
 
 ## 技术栈
 
+| 层级 | 技术 |
+| --- | --- |
+| Web 前端 | Vue 2.6、Vue Router 3、Element UI、Axios、Three.js |
+| 聚合后端 | Java 8、Spring Boot 2.7.5、MyBatis-Plus 3.5、Druid |
+| 推理服务 | Python、PyTorch、SimpleITK、OpenCV、NumPy |
+| 数据存储 | MySQL、Redis、MinIO |
+| 可选微服务 | Spring Cloud 2021、Spring Cloud Alibaba、Nacos、Gateway、OpenFeign |
+| 生产入口 | Nginx、systemd（示例） |
 
-![Static Badge](https://img.shields.io/badge/Spring%20Boot-green)
-![Static Badge](https://img.shields.io/badge/Redis-red)
-![Static Badge](https://img.shields.io/badge/Vue2-skyblue)
-![Static Badge](https://img.shields.io/badge/ElementUI-skyblue)
-![Static Badge](https://img.shields.io/badge/python-skyblue)
-![Static Badge](https://img.shields.io/badge/pytorch-skyblue)
-![Static Badge](https://img.shields.io/badge/opencv-green)
-...
+## 项目结构
 
+```text
+BrainU/
+├── README.md
+├── designSystem/
+│   ├── BrainU-frontend/          # Vue 2 前端
+│   ├── BrainU-backend/           # 推荐使用的 Spring Boot 聚合后端
+│   └── BrainU-micoservice/       # 早期微服务拆分版本，当前不建议作为首次部署入口
+└── python_server/                # PyTorch 推理与切片生成服务，TCP 端口 50007
+```
 
-## 系统部署
-待完善
+核心目录说明：
 
-## 作者
+```text
+designSystem/BrainU-frontend/src/
+├── api/                          # 前端 API 封装
+├── router/                       # 懒加载路由
+├── util/request.js               # Axios 实例，统一请求 /api
+└── views/workSpace/components/   # 医学影像查看器和 Three.js 引擎
 
-- [@peiYp](https://github.com/change-everything)
+designSystem/BrainU-backend/src/main/
+├── java/com/peiyp/brainu/
+│   ├── controller/               # HTTP 接口
+│   ├── service/                  # 业务与 Python Socket 调用
+│   ├── mapper/                   # MyBatis-Plus Mapper
+│   └── config/                   # Redis、MinIO、Web 配置
+└── resources/application.yml     # 默认配置，生产环境必须覆盖敏感值
+```
 
+## 运行架构
 
-## 反馈
+```mermaid
+flowchart LR
+    U[浏览器] -->|HTTPS| N[Nginx]
+    N -->|静态资源| V[Vue dist]
+    N -->|/api| J[Spring Boot :8000]
+    J --> M[(MySQL)]
+    J --> R[(Redis)]
+    J -->|TCP 127.0.0.1:50007| P[Python 推理服务]
+    J --> S[(MinIO)]
+    P -->|上传三向切片| S
+```
 
-如果你有任何反馈，请联系我：pyptsguas@163.com
+一次完整分割流程：
+
+1. 前端把 MRI 文件和患者资料上传到 Spring Boot。
+2. Spring Boot 将上传文件暂存到本机目录，并保存患者、文件和通知记录。
+3. 医生在待诊断病例中选择模型并发起分割。
+4. Spring Boot 通过 TCP `127.0.0.1:50007` 调用 Python 服务。
+5. Python 加载模型和 MRI 数据，生成 `result.mha`。
+6. Python 生成轴位、矢状位和冠状位切片，并上传至 MinIO。
+7. Spring Boot 保存 MinIO 对象路径，前端按需获取预签名 URL 并浏览切片。
+
+## 部署方式选择
+
+仓库中存在两套 Java 后端：
+
+### 方案 A：聚合后端，推荐
+
+目录：`designSystem/BrainU-backend`
+
+- 单个 Spring Boot 服务。
+- 默认端口为 `8000`，上下文路径为 `/api`。
+- 本地搭建、演示和当前生产化改造都应从此方案开始。
+- 不依赖 Nacos 和 Gateway，故障面更小。
+
+### 方案 B：微服务版本，实验性质
+
+目录：`designSystem/BrainU-micoservice`
+
+- 包含 Gateway、Auth、User、Model、TumorSegmentation、Common。
+- 依赖 Nacos、OpenFeign 和多个服务进程。
+- 部分模块声明、配置和硬编码地址尚未完全收口，不能直接视为一键部署版本。
+
+下文除“微服务版本说明”外，均以方案 A 为准。
+
+## 部署前必须确认的事项
+
+当前代码能够展示完整设计，但还存在一些会影响首次运行或生产安全的硬编码。部署前应逐项处理。
+
+### 1. 立即轮换历史凭据
+
+以下文件曾包含明文连接信息：
+
+- `designSystem/BrainU-backend/src/main/resources/application.yml`
+- `designSystem/BrainU-micoservice/**/application.yml`
+- `designSystem/BrainU-micoservice/**/bootstrap.properties`
+- `python_server/test/saveoss.py`
+
+即使这些凭据已经不可用，也应在数据库、Redis、MinIO 和 Nacos 侧执行轮换。不要只修改 Git 最新提交；凭据仍可能存在于 Git 历史中。
+
+### 2. 统一 MinIO 桶名
+
+聚合后端在 `Constants.java` 中使用桶名：
+
+```text
+brainu
+```
+
+Python 的 `saveoss.py` 旧代码使用了另一个桶名。部署时必须将 Python 中所有 `bucket_name` 统一为 `brainu`，或者同时修改 Java 常量和初始化命令，确保两端完全一致。否则 Python 上传成功后，Java 会从另一个桶生成 URL，页面将无法显示切片。
+
+### 3. 修改 Python MinIO 配置
+
+`python_server/test/saveoss.py` 当前直接写入 MinIO endpoint、access key 和 secret key。生产环境至少应改为读取环境变量，例如：
+
+```python
+endpoint = os.environ["BRAINU_MINIO_ENDPOINT"]
+access_key = os.environ["BRAINU_MINIO_ACCESS_KEY"]
+secret_key = os.environ["BRAINU_MINIO_SECRET_KEY"]
+```
+
+当前仓库尚未完成这一重构，因此仅设置环境变量不会自动生效；必须先修改 Python 代码。
+
+### 4. 修正上传暂存目录
+
+`SegmentServiceImpl.folderUpload` 当前使用 `System.getProperty("user.dir")` 拼接文件路径，并对完整文件路径调用 `mkdirs()`。在不同操作系统或工作目录下可能产生错误路径。
+
+生产部署前建议将上传目录改为配置项，例如：
+
+```yaml
+brainu:
+  upload-dir: /var/lib/brainu/uploads
+```
+
+并使用 `Paths.get(uploadDir, fileId, originalFilename)` 创建父目录。Java 与 Python 必须能够访问同一份上传文件。
+
+### 5. Python 与 Java 当前要求同机运行
+
+Java 后端将推理服务地址写死为：
+
+```text
+127.0.0.1:50007
+```
+
+因此当前最稳妥的部署方式是让 Java 和 Python 运行在同一台服务器，并共享本地文件系统。如果拆成两个 Docker 容器或两台服务器，需要同时完成：
+
+- 将 Python host、port 改为配置项。
+- 使用共享卷或对象存储传递原始 MRI 文件。
+- 为 TCP 调用增加超时、失败重试和任务状态。
+
+### 6. 当前 Python 推理流程默认需要 CUDA
+
+`python_server/server.py` 会设置 CUDA 设备。没有 NVIDIA GPU 或 CUDA 环境时，需要先将 `torch.cuda.set_device(...)` 放入 `torch.cuda.is_available()` 判断中，并使用 CPU 版本 PyTorch。CPU 可以运行，但完整体数据推理会明显变慢。
+
+### 7. 输入数据不是任意 MRI 文件
+
+当前 `DataLoaderSelf` 按文件名识别数据，病例目录至少需要包含：
+
+```text
+Case001_Flair.mha
+Case001_T1.mha
+Case001_T1c.mha
+Case001_T2.mha
+Case001_OT.mha
+```
+
+代码通过 `Flair`、`T1`、`T2` 和 `OT.` 等字符串匹配文件，文件名和大小写必须符合规则。当前评估式推理仍依赖 OT 标签；如需处理真实临床无标签数据，应将数据加载和评价逻辑拆开。
+
+## 本地开发环境搭建
+
+### 1. 环境要求
+
+推荐版本：
+
+| 软件 | 推荐版本 | 说明 |
+| --- | --- | --- |
+| Git | 2.40+ | 拉取代码 |
+| JDK | 8 | `pom.xml` 的目标版本 |
+| Maven | 3.8+ | 聚合后端没有提交 Maven Wrapper |
+| Node.js | 16 LTS | Vue CLI 4 与旧依赖在 Node 22/24 下可能不兼容 |
+| npm | 8+ | 前端依赖安装 |
+| Python | 3.8 或 3.9 | 与仓库缓存及旧版科学计算依赖更接近 |
+| MySQL | 5.7 或 8.0 | 数据库名默认 `brainu_db` |
+| Redis | 6+ | 登录 token 存储 |
+| MinIO | 较新稳定版 | 原始文件及切片对象存储 |
+| NVIDIA Driver/CUDA | 与 PyTorch 匹配 | GPU 推理时需要 |
+
+检查版本：
+
+```bash
+java -version
+mvn -version
+node -v
+npm -v
+python --version
+mysql --version
+redis-cli --version
+```
+
+### 2. 获取代码
+
+```bash
+git clone https://github.com/change-everything/BrainU.git
+cd BrainU
+```
+
+### 3. 初始化 MySQL
+
+仓库当前没有独立 SQL 初始化文件，可依据实体创建以下最小表结构：
+
+```sql
+CREATE DATABASE IF NOT EXISTS brainu_db
+  DEFAULT CHARACTER SET utf8mb4
+  DEFAULT COLLATE utf8mb4_unicode_ci;
+
+USE brainu_db;
+
+CREATE TABLE IF NOT EXISTS doctor_info (
+  id INT NOT NULL AUTO_INCREMENT,
+  doctor_name VARCHAR(100) NOT NULL,
+  doctor_id INT NOT NULL,
+  doctor_phone VARCHAR(32) DEFAULT NULL,
+  doctor_email VARCHAR(128) DEFAULT NULL,
+  doctor_office VARCHAR(100) DEFAULT NULL,
+  password VARCHAR(255) NOT NULL,
+  status TINYINT NOT NULL DEFAULT 1,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_doctor_id (doctor_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS patient_info (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  patient_name VARCHAR(100) NOT NULL,
+  patient_age INT DEFAULT NULL,
+  patient_gender TINYINT DEFAULT NULL COMMENT '0=女, 1=男',
+  patient_phone VARCHAR(32) DEFAULT NULL,
+  patient_idcard VARCHAR(32) DEFAULT NULL,
+  handle_by VARCHAR(64) DEFAULT NULL,
+  create_time DATETIME DEFAULT NULL,
+  update_time DATETIME DEFAULT NULL,
+  img_path VARCHAR(512) DEFAULT NULL,
+  is_handle TINYINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (id),
+  KEY idx_patient_handle (is_handle, handle_by),
+  KEY idx_patient_name (patient_name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS brain_file (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  file_id VARCHAR(64) NOT NULL,
+  original_file_name VARCHAR(255) DEFAULT NULL,
+  upload_path VARCHAR(512) NOT NULL,
+  create_time DATETIME DEFAULT NULL,
+  update_time DATETIME DEFAULT NULL,
+  patient_id BIGINT NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_brain_file_patient (patient_id),
+  KEY idx_brain_file_file_id (file_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS model_info (
+  id INT NOT NULL AUTO_INCREMENT,
+  model_name VARCHAR(100) NOT NULL,
+  model_path VARCHAR(512) NOT NULL,
+  model_describe VARCHAR(1000) DEFAULT NULL,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS notify_info (
+  id INT NOT NULL AUTO_INCREMENT,
+  context VARCHAR(500) NOT NULL,
+  create_time DATETIME DEFAULT NULL,
+  is_handle TINYINT NOT NULL DEFAULT 0,
+  patient_id BIGINT NOT NULL,
+  PRIMARY KEY (id),
+  KEY idx_notify_handle (is_handle, create_time),
+  KEY idx_notify_patient (patient_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+创建一个用于首次登录的医生账号。当前代码按明文比较密码，仅适合演示；生产环境必须改成 BCrypt 等密码散列。
+
+```sql
+INSERT INTO doctor_info
+  (doctor_name, doctor_id, doctor_phone, doctor_email, doctor_office, password, status)
+VALUES
+  ('系统管理员', 10001, NULL, 'admin@example.com', '影像科', 'change-me-now', 1);
+```
+
+添加模型记录，`model_path` 必须是 Python 进程能够读取的绝对路径：
+
+```sql
+INSERT INTO model_info (model_name, model_path, model_describe)
+VALUES (
+  'Multi-modal U-Net模型',
+  '/opt/brainu/models/best_epoch.pth',
+  'BrainU Multi-modal U-Net'
+);
+```
+
+模型名如果严格等于 `U-Net模型`，Python 会实例化 `UNet2D`；其他名称会实例化 `Multi_Unet`，因此模型名称和权重结构必须匹配。
+
+### 4. 启动 Redis
+
+使用本机 Redis：
+
+```bash
+redis-server
+redis-cli ping
+```
+
+预期返回：
+
+```text
+PONG
+```
+
+默认代码使用 Redis database `10`。如 Redis 配置了密码，需要同时在 Spring 配置中设置。
+
+### 5. 启动并初始化 MinIO
+
+Docker 示例：
+
+```bash
+docker run -d \
+  --name brainu-minio \
+  -p 9000:9000 \
+  -p 9001:9001 \
+  -e MINIO_ROOT_USER=brainu-admin \
+  -e MINIO_ROOT_PASSWORD='replace-with-a-strong-password' \
+  -v brainu-minio-data:/data \
+  minio/minio server /data --console-address ':9001'
+```
+
+使用 MinIO Client 创建桶：
+
+```bash
+mc alias set local http://127.0.0.1:9000 brainu-admin 'replace-with-a-strong-password'
+mc mb --ignore-existing local/brainu
+mc anonymous set none local/brainu
+```
+
+桶无需公开。前端通过 Java 后端生成的预签名 URL 读取切片。
+
+### 6. 配置聚合后端
+
+推荐新建以下文件，避免修改和提交默认配置：
+
+```text
+designSystem/BrainU-backend/src/main/resources/application-local.yml
+```
+
+后端 `.gitignore` 已忽略该文件。示例：
+
+```yaml
+spring:
+  datasource:
+    url: jdbc:mysql://127.0.0.1:3306/brainu_db?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=Asia/Shanghai
+    username: brainu
+    password: replace-with-your-password
+  redis:
+    host: 127.0.0.1
+    port: 6379
+    password:
+    database: 10
+
+server:
+  port: 8000
+  servlet:
+    context-path: /api
+
+minio:
+  endpoint: http://127.0.0.1:9000
+  user-name: brainu-admin
+  password: replace-with-a-strong-password
+```
+
+创建最小权限数据库用户：
+
+```sql
+CREATE USER IF NOT EXISTS 'brainu'@'%' IDENTIFIED BY 'replace-with-your-password';
+GRANT SELECT, INSERT, UPDATE, DELETE ON brainu_db.* TO 'brainu'@'%';
+FLUSH PRIVILEGES;
+```
+
+### 7. 安装 Python 推理环境
+
+进入 Python 目录并创建虚拟环境：
+
+```bash
+cd python_server
+python -m venv .venv
+
+# Linux/macOS
+source .venv/bin/activate
+
+# Windows PowerShell
+# .\.venv\Scripts\Activate.ps1
+```
+
+PyTorch 应按显卡和 CUDA 版本从官方渠道安装。安装其他依赖：
+
+```bash
+python -m pip install --upgrade pip
+pip install numpy SimpleITK imageio Pillow opencv-python-headless minio matplotlib scipy
+```
+
+还需要安装 `torch`。例如 CPU 调试环境可安装 CPU 版本；GPU 环境必须选择与 CUDA 对应的版本。项目没有提交经过锁定验证的 `requirements.txt`，首次部署后应执行：
+
+```bash
+pip freeze > requirements.lock.txt
+```
+
+然后完成以下代码配置：
+
+1. 将 `saveoss.py` 的 MinIO endpoint 和凭据改成当前环境。
+2. 将所有切片上传桶名统一为 `brainu`。
+3. 确保数据库 `model_info.model_path` 指向实际 `.pth` 权重。
+4. 确保 GPU 机器上的 PyTorch 能识别 CUDA：
+
+```bash
+python -c "import torch; print(torch.__version__); print(torch.cuda.is_available())"
+```
+
+启动推理服务：
+
+```bash
+cd python_server
+source .venv/bin/activate
+python server.py
+```
+
+确认端口：
+
+```bash
+# Linux
+ss -lntp | grep 50007
+
+# Windows PowerShell
+Get-NetTCPConnection -LocalPort 50007
+```
+
+### 8. 启动 Spring Boot 后端
+
+新开终端：
+
+```bash
+cd designSystem/BrainU-backend
+mvn clean compile
+mvn spring-boot:run
+```
+
+后端监听：
+
+```text
+http://127.0.0.1:8000/api
+```
+
+验证登录接口：
+
+```bash
+curl -X POST 'http://127.0.0.1:8000/api/auth/login' \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"10001","password":"change-me-now"}'
+```
+
+接口应返回包含 token 的成功响应。若启动失败，依次确认 MySQL、Redis 和 MinIO 可连接。
+
+### 9. 配置并启动前端
+
+当前 `vue.config.js` 的开发代理指向已有远程地址。本地联调时，建议将代理调整为：
+
+```js
+module.exports = {
+  devServer: {
+    host: '0.0.0.0',
+    port: 28088,
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:8000',
+        changeOrigin: true
+      }
+    }
+  }
+}
+```
+
+这里不要再删除 `/api`，因为聚合后端自身配置了 `/api` context path。
+
+安装依赖并启动：
+
+```bash
+cd designSystem/BrainU-frontend
+npm install
+npm run serve
+```
+
+访问：
+
+```text
+http://127.0.0.1:28088
+```
+
+使用初始化的医生工号和密码登录。
+
+### 10. 推荐启动顺序
+
+```text
+MySQL
+  ↓
+Redis
+  ↓
+MinIO
+  ↓
+Python 推理服务 :50007
+  ↓
+Spring Boot :8000/api
+  ↓
+Vue Dev Server :28088
+```
+
+### 11. 本地功能验收
+
+1. 登录后能进入临床工作台。
+2. 医生管理页面能读取初始化医生。
+3. 模型管理页面能读取模型记录。
+4. 上传符合命名要求的 MRI 病例目录。
+5. 待诊断页面出现新病例。
+6. 选择模型执行分割，Python 终端出现推理日志。
+7. MinIO `brainu` 桶出现 `resultEnv/...` 对象。
+8. 病例变为已诊断状态。
+9. 打开影像工作站，仅加载当前帧及相邻帧，而非一次请求全部切片图片。
+10. 关闭并反复打开查看器，浏览器内存和 GPU 上下文不持续增长。
+
+## 生产环境部署
+
+以下示例以 Ubuntu、Nginx、systemd、单机 Java + Python 为基础。真实临床或互联网环境还需要完善审计、备份、密钥管理、网络隔离和合规措施。
+
+### 1. 推荐目录
+
+```text
+/opt/brainu/
+├── current/                 # 当前代码或发布包
+├── releases/                # 历史发布版本
+├── models/                  # .pth 权重
+├── venv/                    # Python 虚拟环境
+└── frontend/                # Vue dist
+
+/var/lib/brainu/
+├── uploads/                 # MRI 暂存目录
+└── logs/
+
+/etc/brainu/
+├── backend.env
+└── python.env
+```
+
+### 2. 生产配置环境变量
+
+Spring Boot 支持通过环境变量覆盖 `application.yml`：
+
+```bash
+# /etc/brainu/backend.env
+SPRING_DATASOURCE_URL=jdbc:mysql://127.0.0.1:3306/brainu_db?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=Asia/Shanghai
+SPRING_DATASOURCE_USERNAME=brainu
+SPRING_DATASOURCE_PASSWORD=replace-me
+SPRING_REDIS_HOST=127.0.0.1
+SPRING_REDIS_PORT=6379
+SPRING_REDIS_PASSWORD=replace-me
+SPRING_REDIS_DATABASE=10
+MINIO_ENDPOINT=https://minio.example.com
+MINIO_USER_NAME=brainu-app
+MINIO_PASSWORD=replace-me
+SERVER_PORT=8000
+SERVER_SERVLET_CONTEXT_PATH=/api
+```
+
+限制权限：
+
+```bash
+sudo chown root:brainu /etc/brainu/backend.env
+sudo chmod 640 /etc/brainu/backend.env
+```
+
+不要把 `.env`、`application-prod.yml`、MinIO 凭据或模型下载密钥提交到 Git。
+
+### 3. 构建后端
+
+```bash
+cd designSystem/BrainU-backend
+mvn clean package -DskipTests
+```
+
+产物通常位于：
+
+```text
+target/BrainU-backend-0.0.1.jar
+```
+
+部署前可先检查：
+
+```bash
+java -jar target/BrainU-backend-0.0.1.jar --spring.main.web-application-type=none
+```
+
+该命令仍可能尝试初始化数据库组件，不适合作为完整健康检查；正式验收以服务启动和登录接口为准。
+
+### 4. 构建前端
+
+```bash
+cd designSystem/BrainU-frontend
+npm install
+npm run lint
+npm run build
+```
+
+构建产物：
+
+```text
+designSystem/BrainU-frontend/dist/
+```
+
+复制到发布目录：
+
+```bash
+sudo rsync -a --delete dist/ /opt/brainu/frontend/
+```
+
+前端生产请求使用相对路径 `/api`，通常不需要写死后端域名。
+
+### 5. Python systemd 服务
+
+先确保 Python 代码已完成 MinIO 配置改造，并且模型、上传目录可访问。
+
+```ini
+# /etc/systemd/system/brainu-ai.service
+[Unit]
+Description=BrainU PyTorch Inference Service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=brainu
+Group=brainu
+WorkingDirectory=/opt/brainu/current/python_server
+EnvironmentFile=-/etc/brainu/python.env
+Environment=PYTHONUNBUFFERED=1
+Environment=CUDA_VISIBLE_DEVICES=0
+ExecStart=/opt/brainu/venv/bin/python /opt/brainu/current/python_server/server.py
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### 6. Spring Boot systemd 服务
+
+```ini
+# /etc/systemd/system/brainu-backend.service
+[Unit]
+Description=BrainU Spring Boot Backend
+After=network-online.target mysql.service redis-server.service brainu-ai.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=brainu
+Group=brainu
+WorkingDirectory=/var/lib/brainu
+EnvironmentFile=/etc/brainu/backend.env
+ExecStart=/usr/bin/java -Xms512m -Xmx2g -XX:+ExitOnOutOfMemoryError -jar /opt/brainu/current/BrainU-backend.jar
+SuccessExitStatus=143
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target
+```
+
+当前上传代码使用 Java working directory 生成暂存路径。启用此服务前，必须先完成“上传暂存目录”改造，不能仅依赖上面的 `WorkingDirectory`。
+
+加载并启动：
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now brainu-ai
+sudo systemctl enable --now brainu-backend
+sudo systemctl status brainu-ai
+sudo systemctl status brainu-backend
+```
+
+查看日志：
+
+```bash
+journalctl -u brainu-ai -f
+journalctl -u brainu-backend -f
+```
+
+### 7. Nginx 配置
+
+```nginx
+server {
+    listen 80;
+    server_name brainu.example.com;
+
+    # 上线后应改为 HTTPS，并将 HTTP 重定向到 HTTPS。
+    root /opt/brainu/frontend;
+    index index.html;
+
+    client_max_body_size 1g;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # MRI 上传和模型推理耗时较长。
+        proxy_request_buffering off;
+        proxy_buffering off;
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 1800s;
+        proxy_read_timeout 1800s;
+    }
+
+    location ~* \.(js|css|png|jpg|jpeg|gif|svg|ico|woff2?)$ {
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800, immutable";
+        try_files $uri =404;
+    }
+}
+```
+
+检查并重载：
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+如果 MinIO 返回给浏览器的是预签名 URL，`minio.endpoint` 必须是浏览器能够访问的 HTTPS 地址。生产环境建议为 MinIO 使用独立域名，例如 `https://minio.example.com`，并配置有效证书。
+
+### 8. 防火墙与网络
+
+建议只公开：
+
+| 端口 | 用途 | 是否公开 |
+| --- | --- | --- |
+| 80/443 | Nginx | 是 |
+| 8000 | Spring Boot | 否，仅本机或内网 |
+| 50007 | Python TCP | 否，仅本机 |
+| 3306 | MySQL | 否 |
+| 6379 | Redis | 否 |
+| 9000 | MinIO API | 通过 HTTPS 反代或受控网络 |
+| 9001 | MinIO Console | 仅管理员网络 |
+
+### 9. 上线验收
+
+```bash
+curl -I https://brainu.example.com/
+
+curl -X POST 'https://brainu.example.com/api/auth/login' \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"10001","password":"your-password"}'
+
+redis-cli -h 127.0.0.1 ping
+mysql -h 127.0.0.1 -u brainu -p -e 'SELECT COUNT(*) FROM brainu_db.doctor_info;'
+mc ls production/brainu
+```
+
+还应在浏览器开发者工具中确认：
+
+- 首页只加载当前路由所需 chunk。
+- `medical-viewer` chunk 仅在打开影像查看器时加载。
+- 每个方向只存在一个切片 `<img>` 节点。
+- 滚动切片时只预取前后邻近帧。
+- 所有 API 和 MinIO URL 均使用 HTTPS。
+
+### 10. 数据备份
+
+至少备份以下内容：
+
+- MySQL `brainu_db`。
+- MinIO `brainu` 桶。
+- 模型权重目录 `/opt/brainu/models`。
+- 非 Git 管理的生产配置与密钥引用。
+- 如需保留原始推理文件，备份 `/var/lib/brainu/uploads`。
+
+示例：
+
+```bash
+mysqldump --single-transaction -u brainu -p brainu_db | gzip > brainu_db_$(date +%F).sql.gz
+mc mirror --overwrite production/brainu /backup/brainu-minio
+```
+
+## 微服务版本说明
+
+微服务目录中的默认端口：
+
+| 模块 | 端口 | 服务名 |
+| --- | --- | --- |
+| Gateway | 88 | `brainU-gateway` |
+| Auth | 6000 | `brainU-auth` |
+| User | 7000 | `brainU-user` |
+| TumorSegmentation | 8000 | `brainU-tumorSegment` |
+| Model | 9000 | `brainU-model` |
+| Nacos | 8848 | 外部依赖 |
+
+目前需要先处理以下问题：
+
+1. 父 `pom.xml` 的 modules 列表未包含 `BrainU-Auth`，构建全部模块前应补充。
+2. 多个 `application.yml` 和 `bootstrap.properties` 写死了远程地址及凭据。
+3. 各服务需统一数据库、Redis、MinIO 和 Nacos 配置来源。
+4. Gateway 端口为 88，前端生产 `/api` 路由需要相应调整。
+5. Python Socket 和本地文件共享问题仍然存在。
+
+完成改造后的启动顺序应为：
+
+```text
+MySQL / Redis / MinIO / Nacos
+  → BrainU-User / BrainU-Model / BrainU-Auth
+  → BrainU-TumorSegmentation / Python
+  → BrainU-Gateway
+  → Vue / Nginx
+```
+
+首次部署不建议使用微服务版本。
+
+## 日常更新与回滚
+
+推荐发布流程：
+
+1. 在新目录构建后端和前端。
+2. 将发布文件复制到带版本号的 `/opt/brainu/releases/<version>`。
+3. 执行数据库备份。
+4. 更新 `current` 软链接。
+5. 重启后端，重载 Nginx。
+6. 执行登录、病例列表和影像预览冒烟测试。
+
+示例：
+
+```bash
+sudo ln -sfn /opt/brainu/releases/2026-07-10 /opt/brainu/current
+sudo systemctl restart brainu-ai
+sudo systemctl restart brainu-backend
+sudo systemctl reload nginx
+```
+
+回滚：
+
+```bash
+sudo ln -sfn /opt/brainu/releases/<previous-version> /opt/brainu/current
+sudo systemctl restart brainu-ai brainu-backend
+sudo systemctl reload nginx
+```
+
+数据库变更必须使用可回滚迁移脚本；当前项目尚未接入 Flyway 或 Liquibase，生产化时建议补充。
+
+## 常见问题
+
+### 前端请求 `/api` 返回 404
+
+- 本地代理不要错误删除 `/api`。
+- 聚合后端的 context path 为 `/api`。
+- Nginx `proxy_pass` 应保留原始 URI。
+
+### 前端可以登录，但其他接口提示认证过期
+
+- 确认 Redis 正常。
+- 确认登录与后续请求连接同一个 Redis database。
+- 确认浏览器请求携带 `Authorization: Bearer <token>`。
+- Token 默认有效期为 60 分钟。
+
+### 上传失败或目录异常
+
+- 优先检查 `SegmentServiceImpl.folderUpload` 的路径拼接和目录创建逻辑。
+- 检查 Java 进程对上传目录的写权限。
+- 检查 Nginx 与 Spring 的 1 GB 上传限制。
+
+### 点击分割后连接被拒绝
+
+```text
+Connection refused: 127.0.0.1:50007
+```
+
+- Python 服务未启动。
+- Python 启动时因 CUDA、模型或依赖错误退出。
+- Java 与 Python 不在同一网络命名空间。
+
+### Python 找不到模型
+
+- `model_info.model_path` 必须是 Python 机器上的绝对路径。
+- 模型名称必须与网络类型匹配。
+- Windows 路径不能直接用于 Linux 服务器。
+
+### Python 找不到 Flair 或 OT 文件
+
+- 检查文件命名及大小写。
+- 当前代码要求标签文件名包含 `OT.`。
+- 检查上传目录中是否实际保存了全部模态。
+
+### 分割成功但页面没有切片
+
+- 检查 Python 与 Java 的 MinIO endpoint、桶名是否一致。
+- 检查对象路径是否为 `resultEnv/<uuid>/se`、`seFont`、`seSide`。
+- 检查 MinIO endpoint 是否能被浏览器访问。
+- 检查服务器时间，预签名 URL 对时钟偏差敏感。
+
+### 前端构建提示包体积过大
+
+Three.js 医学查看器已经拆为异步 chunk，但 Element UI、Vue 2 和 Three.js 本身仍有一定体积。构建 warning 不会阻止产物生成。后续可继续：
+
+- 移除未使用组件和图片预览插件。
+- 压缩登录页背景图。
+- 升级 Vue CLI 或迁移 Vite。
+- 对 Three.js 功能做更细粒度拆分。
+
+### Node 22/24 构建 Vue CLI 4 报错
+
+旧版 `@vue/cli-service` 及其 `node-ipc` 依赖与新 Node 版本可能不兼容。优先使用 Node 16 LTS 构建；长期方案是升级构建工具。
+
+## 模型与实验结果
+
+### Multi-modal U-Net
+
+![Multi-modal U-Net](designSystem/BrainU-backend/img/mmunet.png)
+
+模型参数结构：
+
+![模型参数表](designSystem/BrainU-backend/img/paaramtable.png)
+![模型参数表 2](designSystem/BrainU-backend/img/table2.png)
+![模型参数表 3](designSystem/BrainU-backend/img/table3.png)
+
+训练环境：
+
+![训练环境](designSystem/BrainU-backend/img/env.png)
+![训练环境 2](designSystem/BrainU-backend/img/env2.png)
+
+神经网络结构参数：
+
+![U-Net 参数](designSystem/BrainU-backend/img/unetparams.png)
+
+- `batch_size`：每次训练使用的样本数。
+- `epoch`：完整遍历训练数据的轮数。
+- `patience`：验证指标连续无提升时允许等待的轮数。
+- `learning rate drop`：训练过程中学习率下降策略。
+- `early stop`：验证性能不再提升时提前结束训练。
+- `initial learning rate`：初始学习率，实验使用 Adam 优化器。
+
+实验展示中，从左到右为 Flair、T1、T1c、T2、模型预测掩模和真实掩模：
+
+![实验结果](designSystem/BrainU-backend/img/result.png)
+
+历史实验记录中的 IoU：标签 0 为 99.6%，标签 1、2、3、4 分别为 78.4%、83.9%、75% 和 87.2%。这些数值来自既有实验展示，不代表医疗产品性能承诺。
+
+![实验结果 2](designSystem/BrainU-backend/img/result1.png)
+
+## 设计资料
+
+- [系统架构图](designSystem/BrainU-backend/img/system.png)
+- [业务流程图](designSystem/BrainU-backend/img/process.png)
+- [模块设计图](designSystem/BrainU-backend/img/design.png)
+- [系统用例图](designSystem/BrainU-backend/img/use.png)
+- [肿瘤分割时序图](designSystem/BrainU-backend/img/timep.png)
+
+## 界面截图
+
+### 登录
+
+![登录](designSystem/BrainU-backend/img/login.png)
+
+### 数据添加
+
+![数据添加](designSystem/BrainU-backend/img/add.png)
+![数据添加 2](designSystem/BrainU-backend/img/add2.png)
+
+### 工作空间
+
+![工作空间](designSystem/BrainU-backend/img/p1.png)
+![工作空间 2](designSystem/BrainU-backend/img/p2.png)
+
+### 肿瘤交互
+
+![肿瘤交互](designSystem/BrainU-backend/img/tumor.png)
+
+### 模型与医生管理
+
+![模型管理](designSystem/BrainU-backend/img/model.png)
+![医生管理](designSystem/BrainU-backend/img/doctor.png)
+
+## 作者与反馈
+
+- GitHub：[@change-everything](https://github.com/change-everything)
+- Email：pyptsguas@163.com
 

--- a/README.md
+++ b/README.md
@@ -1,129 +1,127 @@
-# BrainU
 
-![BrainU Logo](designSystem/BrainU-backend/img/logo.png)
+![logo.png](designSystem%2FBrainU-backend%2Fimg%2Flogo.png)
 
-BrainU 是一个面向脑部 MRI 的肿瘤分割与医学影像浏览平台。系统由 Vue 2 临床工作台、Spring Boot 聚合服务、Python/PyTorch 推理服务以及 MySQL、Redis、MinIO 等基础设施组成，支持病例管理、MRI 文件上传、模型选择、肿瘤分割、三向切片浏览和结果下载。
 
-> [!WARNING]
-> 本项目目前属于教学、科研和工程验证性质，不是经过医疗器械认证的诊断系统，不能直接用于临床诊断或治疗决策。
+# brainU
+## 项目介绍
 
-> [!CAUTION]
-> 仓库历史配置中存在数据库、Redis、MinIO 地址及凭据硬编码。公开部署前必须轮换相关凭据，并使用本地配置文件或环境变量覆盖，禁止继续使用仓库中出现过的任何密码。
+基于多模态UNet神经网络+Pytorch+opencv+SpringBoot+Vue2的脑肿瘤自动分割web平台项目。用户可以针对某个病人的脑肿瘤核磁共振扫描的文件上传平台进行肿瘤分割。
 
-## 目录
+## 模型训练
+### Multi-modal U-Net
+![mmunet.png](designSystem%2FBrainU-backend%2Fimg%2Fmmunet.png)
+#### 复现
+##### 模型参数结构表
+![paaramtable.png](designSystem%2FBrainU-backend%2Fimg%2Fpaaramtable.png)
+![table2.png](designSystem%2FBrainU-backend%2Fimg%2Ftable2.png)
+![table3.png](designSystem%2FBrainU-backend%2Fimg%2Ftable3.png)
 
-- [功能概览](#功能概览)
-- [技术栈](#技术栈)
-- [项目结构](#项目结构)
-- [运行架构](#运行架构)
-- [部署方式选择](#部署方式选择)
-- [部署前必须确认的事项](#部署前必须确认的事项)
-- [本地开发环境搭建](#本地开发环境搭建)
-- [生产环境部署](#生产环境部署)
-- [微服务版本说明](#微服务版本说明)
-- [日常更新与回滚](#日常更新与回滚)
-- [常见问题](#常见问题)
-- [模型与实验结果](#模型与实验结果)
+##### 训练环境
+![env.png](designSystem%2FBrainU-backend%2Fimg%2Fenv.png)
+![env2.png](designSystem%2FBrainU-backend%2Fimg%2Fenv2.png)
 
-## 功能概览
+##### 神经网络结构参数
+![unetparams.png](designSystem%2FBrainU-backend%2Fimg%2Funetparams.png)
+- batch_size:指定每次训练时使用的样本数。较大的 batch_size 能够提高训练速度，
+但可能会降低模型的准确性。
+- epoch: 指定训练的轮数。每一轮训练都会使用全部的训练数据，这有助于模型逐渐
+提高准确性，但如果训练轮数过多，可能会导致过拟合。
+- patience: 指定在验证集上连续多少个 epoch 的性能没有提升时，停止训练。这可以
+避免过拟合和浪费时间和计算资源。
+- learning rate drop: 当模型训练到一定程度时，为了避免过拟合和提高准确性，我
+们可以降低学习率。此超参数可以指定学习率下降的速度和幅度。
+- early stop: 当模型在验证集上的性能不再提升时，可以提前停止训练以节省时间和
+计算资源。此超参数可以指定在多少个 epoch 没有提升时，停止训练。
+- initial learning rate: 指定模型最初的学习率。较高的学习率可以提高训练速度，
+但可能会导致模型不稳定和性能下降，本次训练使用 Adam 自适应学习率算法，所以算法
+将根据损失函数的变化情况自动调整学习率的大小。
 
-- 医生账号登录与基于 JWT、Redis 的会话校验。
-- 患者资料、待诊断病例和已诊断病例管理。
-- 批量上传 `.mha` MRI 序列及患者资料。
-- 选择 U-Net 或 Multi-modal U-Net 模型执行分割。
-- 将分割结果和原始切片上传至 MinIO。
-- 轴位、矢状位、冠状位和三维定位视图联动浏览。
-- 当前切片按需加载，并预取相邻切片，避免一次性加载数百张图像。
-- 原始影像与分割结果切换、当前切片下载、结果文件下载。
-- 模型信息、医生信息和诊断通知管理。
+##### 实验结果
+- Multi-modal U-Net脑部胶质瘤分割示例，从左到右分别为磁共振成像液体衰减反转序
+  列、T1 加权成像、T1c造影剂成像、T2 加权成像、模型预测的肿瘤掩模图以及真实的肿瘤掩模图
+![result.png](designSystem%2FBrainU-backend%2Fimg%2Fresult.png)
+
+- IoU 测量每个类别的预测标签和
+  地面实况标签之间的重叠。发现标签 0 的 IoU 为 99.6%，表明该模型准确地识别了此类。
+  标签 1、2 和 3 的 IoU 值也相对较高，分别为 78.4%、83.9%和 75%。这表明该模型能够准
+  确识别这些类，尽管还有一些改进的空间。另一方面，发现标签 4 的 IoU 为 87.2%，表明
+  该模型能够准确识别这一类别。
+
+![result1.png](designSystem%2FBrainU-backend%2Fimg%2Fresult1.png)
+
+
+
+## 架构图
+![system.png](designSystem%2FBrainU-backend%2Fimg%2Fsystem.png)
+
+## 流程图
+![process.png](designSystem%2FBrainU-backend%2Fimg%2Fprocess.png)
+
+## 模块设计图
+![design.png](designSystem%2FBrainU-backend%2Fimg%2Fdesign.png)
+
+## 系统用例图
+![use.png](designSystem%2FBrainU-backend%2Fimg%2Fuse.png)
+
+## 时序图
+### 肿瘤分割
+![timep.png](designSystem%2FBrainU-backend%2Fimg%2Ftimep.png)
+
+
+## 项目亮点
+
+1. **成功复现UNet和muti-modal UNet网络：**
+   - 基于PyTorch框架，成功复现了UNet和muti-modal UNet网络，并利用2015年脑肿瘤分割大赛的数据集进行训练。
+   - 对数据集进行了有效的预处理，并划分为训练集和测试集，在实测中达到了95%的准确率。
+
+2. **前后端交互实现在线脑肿瘤分割：**
+   - 借助Spring Boot和Vue框架，实现了系统的后端和前端交互。
+   - 调用自己开发的脑肿瘤分割接口，实现了在线脑肿瘤分割，为用户提供了便捷的服务。
+
+3. **数据可靠存储和高效管理：**
+   - 使用Minio进行数据的可靠存储和高效管理，将用户上传的脑部MRI影像保存到Minio中，保证了数据的安全性和可靠性。
+
+4. **引入评分机制实现模型的可迭代性：**
+   - 引入评分机制，用户可以对本次分割的精准度进行评分。
+   - 如果分数高于阈值，将本次训练参数保存到模型文件中，实现了模型的自我训练和迭代优化。
+
+
+
+## 截图
+### 登录
+![login.png](designSystem%2FBrainU-backend%2Fimg%2Flogin.png)
+### 数据添加
+![add.png](designSystem%2FBrainU-backend%2Fimg%2Fadd.png)
+![add2.png](designSystem%2FBrainU-backend%2Fimg%2Fadd2.png)
+### 工作空间
+![p1.png](designSystem%2FBrainU-backend%2Fimg%2Fp1.png)
+![p2.png](designSystem%2FBrainU-backend%2Fimg%2Fp2.png)
+### 肿瘤交互
+![tumor.png](designSystem%2FBrainU-backend%2Fimg%2Ftumor.png)
+### 模型管理
+![model.png](designSystem%2FBrainU-backend%2Fimg%2Fmodel.png)
+### 医生管理
+![doctor.png](designSystem%2FBrainU-backend%2Fimg%2Fdoctor.png)
 
 ## 技术栈
 
-| 层级 | 技术 |
-| --- | --- |
-| Web 前端 | Vue 2.6、Vue Router 3、Element UI、Axios、Three.js |
-| 聚合后端 | Java 8、Spring Boot 2.7.5、MyBatis-Plus 3.5、Druid |
-| 推理服务 | Python、PyTorch、SimpleITK、OpenCV、NumPy |
-| 数据存储 | MySQL、Redis、MinIO |
-| 可选微服务 | Spring Cloud 2021、Spring Cloud Alibaba、Nacos、Gateway、OpenFeign |
-| 生产入口 | Nginx、systemd（示例） |
 
-## 项目结构
+![Static Badge](https://img.shields.io/badge/Spring%20Boot-green)
+![Static Badge](https://img.shields.io/badge/Redis-red)
+![Static Badge](https://img.shields.io/badge/Vue2-skyblue)
+![Static Badge](https://img.shields.io/badge/ElementUI-skyblue)
+![Static Badge](https://img.shields.io/badge/python-skyblue)
+![Static Badge](https://img.shields.io/badge/pytorch-skyblue)
+![Static Badge](https://img.shields.io/badge/opencv-green)
+...
 
-```text
-BrainU/
-├── README.md
-├── designSystem/
-│   ├── BrainU-frontend/          # Vue 2 前端
-│   ├── BrainU-backend/           # 推荐使用的 Spring Boot 聚合后端
-│   └── BrainU-micoservice/       # 早期微服务拆分版本，当前不建议作为首次部署入口
-└── python_server/                # PyTorch 推理与切片生成服务，TCP 端口 50007
-```
 
-核心目录说明：
+## 系统搭建与部署
 
-```text
-designSystem/BrainU-frontend/src/
-├── api/                          # 前端 API 封装
-├── router/                       # 懒加载路由
-├── util/request.js               # Axios 实例，统一请求 /api
-└── views/workSpace/components/   # 医学影像查看器和 Three.js 引擎
+以下流程根据当前仓库代码整理。推荐优先部署 `designSystem/BrainU-backend` 聚合后端；`designSystem/BrainU-micoservice` 属于早期微服务拆分版本，首次搭建不建议使用。
 
-designSystem/BrainU-backend/src/main/
-├── java/com/peiyp/brainu/
-│   ├── controller/               # HTTP 接口
-│   ├── service/                  # 业务与 Python Socket 调用
-│   ├── mapper/                   # MyBatis-Plus Mapper
-│   └── config/                   # Redis、MinIO、Web 配置
-└── resources/application.yml     # 默认配置，生产环境必须覆盖敏感值
-```
-
-## 运行架构
-
-```mermaid
-flowchart LR
-    U[浏览器] -->|HTTPS| N[Nginx]
-    N -->|静态资源| V[Vue dist]
-    N -->|/api| J[Spring Boot :8000]
-    J --> M[(MySQL)]
-    J --> R[(Redis)]
-    J -->|TCP 127.0.0.1:50007| P[Python 推理服务]
-    J --> S[(MinIO)]
-    P -->|上传三向切片| S
-```
-
-一次完整分割流程：
-
-1. 前端把 MRI 文件和患者资料上传到 Spring Boot。
-2. Spring Boot 将上传文件暂存到本机目录，并保存患者、文件和通知记录。
-3. 医生在待诊断病例中选择模型并发起分割。
-4. Spring Boot 通过 TCP `127.0.0.1:50007` 调用 Python 服务。
-5. Python 加载模型和 MRI 数据，生成 `result.mha`。
-6. Python 生成轴位、矢状位和冠状位切片，并上传至 MinIO。
-7. Spring Boot 保存 MinIO 对象路径，前端按需获取预签名 URL 并浏览切片。
-
-## 部署方式选择
-
-仓库中存在两套 Java 后端：
-
-### 方案 A：聚合后端，推荐
-
-目录：`designSystem/BrainU-backend`
-
-- 单个 Spring Boot 服务。
-- 默认端口为 `8000`，上下文路径为 `/api`。
-- 本地搭建、演示和当前生产化改造都应从此方案开始。
-- 不依赖 Nacos 和 Gateway，故障面更小。
-
-### 方案 B：微服务版本，实验性质
-
-目录：`designSystem/BrainU-micoservice`
-
-- 包含 Gateway、Auth、User、Model、TumorSegmentation、Common。
-- 依赖 Nacos、OpenFeign 和多个服务进程。
-- 部分模块声明、配置和硬编码地址尚未完全收口，不能直接视为一键部署版本。
-
-下文除“微服务版本说明”外，均以方案 A 为准。
+> [!WARNING]
+> 本项目用于教学、科研和工程验证，未经过医疗器械认证，不能直接用于临床诊断或治疗决策。
 
 ## 部署前必须确认的事项
 
@@ -974,77 +972,11 @@ Three.js 医学查看器已经拆为异步 chunk，但 Element UI、Vue 2 和 Th
 
 旧版 `@vue/cli-service` 及其 `node-ipc` 依赖与新 Node 版本可能不兼容。优先使用 Node 16 LTS 构建；长期方案是升级构建工具。
 
-## 模型与实验结果
+## 作者
 
-### Multi-modal U-Net
+- [@peiYp](https://github.com/change-everything)
 
-![Multi-modal U-Net](designSystem/BrainU-backend/img/mmunet.png)
 
-模型参数结构：
+## 反馈
 
-![模型参数表](designSystem/BrainU-backend/img/paaramtable.png)
-![模型参数表 2](designSystem/BrainU-backend/img/table2.png)
-![模型参数表 3](designSystem/BrainU-backend/img/table3.png)
-
-训练环境：
-
-![训练环境](designSystem/BrainU-backend/img/env.png)
-![训练环境 2](designSystem/BrainU-backend/img/env2.png)
-
-神经网络结构参数：
-
-![U-Net 参数](designSystem/BrainU-backend/img/unetparams.png)
-
-- `batch_size`：每次训练使用的样本数。
-- `epoch`：完整遍历训练数据的轮数。
-- `patience`：验证指标连续无提升时允许等待的轮数。
-- `learning rate drop`：训练过程中学习率下降策略。
-- `early stop`：验证性能不再提升时提前结束训练。
-- `initial learning rate`：初始学习率，实验使用 Adam 优化器。
-
-实验展示中，从左到右为 Flair、T1、T1c、T2、模型预测掩模和真实掩模：
-
-![实验结果](designSystem/BrainU-backend/img/result.png)
-
-历史实验记录中的 IoU：标签 0 为 99.6%，标签 1、2、3、4 分别为 78.4%、83.9%、75% 和 87.2%。这些数值来自既有实验展示，不代表医疗产品性能承诺。
-
-![实验结果 2](designSystem/BrainU-backend/img/result1.png)
-
-## 设计资料
-
-- [系统架构图](designSystem/BrainU-backend/img/system.png)
-- [业务流程图](designSystem/BrainU-backend/img/process.png)
-- [模块设计图](designSystem/BrainU-backend/img/design.png)
-- [系统用例图](designSystem/BrainU-backend/img/use.png)
-- [肿瘤分割时序图](designSystem/BrainU-backend/img/timep.png)
-
-## 界面截图
-
-### 登录
-
-![登录](designSystem/BrainU-backend/img/login.png)
-
-### 数据添加
-
-![数据添加](designSystem/BrainU-backend/img/add.png)
-![数据添加 2](designSystem/BrainU-backend/img/add2.png)
-
-### 工作空间
-
-![工作空间](designSystem/BrainU-backend/img/p1.png)
-![工作空间 2](designSystem/BrainU-backend/img/p2.png)
-
-### 肿瘤交互
-
-![肿瘤交互](designSystem/BrainU-backend/img/tumor.png)
-
-### 模型与医生管理
-
-![模型管理](designSystem/BrainU-backend/img/model.png)
-![医生管理](designSystem/BrainU-backend/img/doctor.png)
-
-## 作者与反馈
-
-- GitHub：[@change-everything](https://github.com/change-everything)
-- Email：pyptsguas@163.com
-
+如果你有任何反馈，请联系我：pyptsguas@163.com

--- a/designSystem/BrainU-frontend/babel.config.js
+++ b/designSystem/BrainU-frontend/babel.config.js
@@ -3,6 +3,12 @@ module.exports = {
     // https://github.com/vuejs/vue-cli/tree/master/packages/@vue/babel-preset-app
     '@vue/cli-plugin-babel/preset'
   ],
+  plugins: [
+    ['component', {
+      libraryName: 'element-ui',
+      styleLibraryName: 'theme-chalk'
+    }]
+  ],
   'env': {
     'development': {
       // babel-plugin-dynamic-import-node plugin only does one thing by converting all import() to require().

--- a/designSystem/BrainU-frontend/package.json
+++ b/designSystem/BrainU-frontend/package.json
@@ -8,7 +8,6 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@kitware/vtk.js": "^28.2.0",
     "axios": "^1.3.4",
     "core-js": "^3.6.5",
     "element-ui": "^2.15.13",
@@ -16,7 +15,6 @@
     "less": "^4.1.3",
     "less-loader": "^7.3.0",
     "three": "^0.152.2",
-    "vtk.js": "^28.2.0",
     "vue": "^2.6.11",
     "vue-cookies": "^1.8.3",
     "vue-router": "^3.6.5"
@@ -27,9 +25,9 @@
     "@vue/cli-plugin-eslint": "~4.5.13",
     "@vue/cli-service": "~4.5.13",
     "babel-eslint": "^10.1.0",
+    "babel-plugin-component": "^1.1.1",
     "eslint": "^6.7.2",
     "eslint-plugin-vue": "^6.2.2",
-    "kw-web-suite": "^11.1.0",
     "sass": "^1.59.3",
     "sass-loader": "^7.3.1",
     "vue-directive-image-previewer": "^2.2.2",

--- a/designSystem/BrainU-frontend/src/assets/css/global.css
+++ b/designSystem/BrainU-frontend/src/assets/css/global.css
@@ -1,3 +1,13 @@
+:root {
+    --clinical-primary: #168d8d;
+    --clinical-primary-dark: #0c646b;
+    --clinical-text: #1a2b3b;
+    --clinical-muted: #708894;
+    --clinical-border: #dfe8ec;
+    --clinical-surface: #ffffff;
+    --clinical-background: #f3f7f9;
+}
+
 html,
 body,
 #app {
@@ -6,3 +16,36 @@ body,
     height: 100%;
     width: 100%;
 }
+
+html { font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif; }
+body { color: var(--clinical-text); background: var(--clinical-background); -webkit-font-smoothing: antialiased; }
+*, *::before, *::after { box-sizing: border-box; }
+button, input, select, textarea { font: inherit; }
+
+.clinical-main > div > .el-card,
+.clinical-main > .el-card {
+    border: 1px solid var(--clinical-border);
+    border-radius: 10px;
+    box-shadow: 0 5px 18px rgba(25, 60, 78, .045);
+}
+
+.clinical-main .el-button--primary {
+    background: var(--clinical-primary);
+    border-color: var(--clinical-primary);
+}
+
+.clinical-main .el-button--primary:hover,
+.clinical-main .el-button--primary:focus {
+    background: #1aa1a0;
+    border-color: #1aa1a0;
+}
+
+.clinical-main .el-table th {
+    color: #607986;
+    background: #f6f9fa;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.clinical-main .el-table td { color: #304753; }
+.clinical-main .el-pagination.is-background .el-pager li:not(.disabled).active { background: var(--clinical-primary); }

--- a/designSystem/BrainU-frontend/src/main.js
+++ b/designSystem/BrainU-frontend/src/main.js
@@ -2,28 +2,32 @@ import Vue from 'vue'
 import App from './App.vue'
 import router from './router'
 import axios from 'axios'
+import {
+  Avatar, Badge, Button, Card, Col, Collapse, CollapseItem, Dialog, Drawer,
+  Dropdown, DropdownItem, DropdownMenu, Empty, Form, FormItem, Image, Input,
+  Link, Menu, MenuItem, Option, Pagination, Popover, Rate, Row, Select, Slider,
+  Step, Steps, Submenu, Table, TableColumn, Tag, Upload, Loading, Message, MessageBox
+} from 'element-ui'
+import './assets/css/global.css'
 
-import ElementUI from 'element-ui';                      // 引入element-ui
-import 'element-ui/lib/theme-chalk/index.css';
-// fade/zoom 等
-import 'element-ui/lib/theme-chalk/base.css';
-import './assets/css/global.css';
-
-//图片放大组件
 import VueDirectiveImagePreviewer from 'vue-directive-image-previewer'
 import 'vue-directive-image-previewer/dist/assets/style.css'
+
+[
+  Avatar, Badge, Button, Card, Col, Collapse, CollapseItem, Dialog, Drawer,
+  Dropdown, DropdownItem, DropdownMenu, Empty, Form, FormItem, Image, Input,
+  Link, Menu, MenuItem, Option, Pagination, Popover, Rate, Row, Select, Slider,
+  Step, Steps, Submenu, Table, TableColumn, Tag, Upload
+].forEach(component => Vue.use(component))
+
+Vue.use(Loading.directive)
 Vue.use(VueDirectiveImagePreviewer)
+Vue.prototype.$loading = Loading.service
+Vue.prototype.$message = Message
+Vue.prototype.$confirm = MessageBox.confirm
 
-axios.defaults.baseURL = 'http://localhost:8989';
-
+axios.defaults.baseURL = process.env.VUE_APP_API_BASE_URL || 'http://localhost:8989'
+Vue.prototype.$axios = axios
 Vue.config.productionTip = false
-//全局挂载
-Vue.prototype.$axios = axios;
 
-Vue.use(ElementUI);
-
-new Vue({
-  render: h => h(App),
-  router,
-  axios
-}).$mount('#app')
+new Vue({ router, render: h => h(App) }).$mount('#app')

--- a/designSystem/BrainU-frontend/src/router/index.js
+++ b/designSystem/BrainU-frontend/src/router/index.js
@@ -1,110 +1,54 @@
-import Index from '../views/index'
-import GetStart from '../views/segment/getStart'
-import UploadAndSegment from '../views/segment/uploadAndSegment'
-import WorkSpace from '../views/workSpace/workSpace'
-import NewPatients from '../views/workSpace/newPatients'
-import ModelManage from '../views/model/index'
-import DoctorManage from '../views/doctor/index'
-import Login from '../views/login'
-
 import Vue from 'vue'
 import VueRouter from 'vue-router'
-
 import { getToken } from '@/util/auth'
 
-//2. 调用Vue.use()函数，把VueRouter安装为Vue的插件
 Vue.use(VueRouter)
 
+// Keep the login and application shell small. Feature pages (especially the
+// Three.js medical viewer) are downloaded only when the user opens them.
+const Index = () => import(/* webpackChunkName: "layout" */ '../views/index')
+const Login = () => import(/* webpackChunkName: "auth" */ '../views/login')
+const GetStart = () => import(/* webpackChunkName: "guide" */ '../views/segment/getStart')
+const UploadAndSegment = () => import(/* webpackChunkName: "segment" */ '../views/segment/uploadAndSegment')
+const WorkSpace = () => import(/* webpackChunkName: "workspace" */ '../views/workSpace/workSpace')
+const NewPatients = () => import(/* webpackChunkName: "workspace" */ '../views/workSpace/newPatients')
+const ModelManage = () => import(/* webpackChunkName: "management" */ '../views/model/index')
+const DoctorManage = () => import(/* webpackChunkName: "management" */ '../views/doctor/index')
 
 const router = new VueRouter({
-    mode: 'history', // 去掉url中的#
+    mode: 'history',
     scrollBehavior: () => ({ y: 0 }),
     routes: [
         {
             path: '/login',
             component: Login,
             name: '登录',
-            meta: { title: '登录' },
-            requiresAuth: false
+            meta: { title: '登录 · BrainU' }
         },
         {
             path: '/',
             component: Index,
             name: '首页',
-            meta: { title: '首页' },
+            redirect: '/getStart',
             children: [
-                {
-                    path: '/getStart',
-                    component: GetStart,
-                    name: '快速开始',
-                    meta: { title: '快速开始' },
-                    requiresAuth: true
-                },
-                {
-                    path: '/segment',
-                    component: UploadAndSegment,
-                    name: '数据添加',
-                    meta: { title: '数据添加' },
-                    requiresAuth: true
-                },
-                {
-                    path: '/workSpace',
-                    component: WorkSpace,
-                    name: '已诊断患者',
-                    meta: { title: '工作空间' },
-                    requiresAuth: true
-                },
-                {
-                    path: '/newPatients',
-                    component: NewPatients,
-                    name: '未诊断患者',
-                    meta: { title: '工作空间' },
-                    requiresAuth: true
-                },
-                {
-                    path: '/modelManage',
-                    component: ModelManage,
-                    name: '模型信息管理',
-                    meta: { title: '模型信息管理' },
-                    requiresAuth: true
-                },
-                {
-                    path: '/doctorManage',
-                    component: DoctorManage,
-                    name: '医生信息管理',
-                    meta: { title: '医生信息管理' },
-                    requiresAuth: true
-                }
+                { path: '/getStart', component: GetStart, name: '快速开始', meta: { title: '临床概览 · BrainU', requiresAuth: true } },
+                { path: '/segment', component: UploadAndSegment, name: '数据添加', meta: { title: '导入影像 · BrainU', requiresAuth: true } },
+                { path: '/workSpace', component: WorkSpace, name: '已诊断患者', meta: { title: '已诊断病例 · BrainU', requiresAuth: true } },
+                { path: '/newPatients', component: NewPatients, name: '未诊断患者', meta: { title: '待诊断病例 · BrainU', requiresAuth: true } },
+                { path: '/modelManage', component: ModelManage, name: '模型信息管理', meta: { title: '模型管理 · BrainU', requiresAuth: true } },
+                { path: '/doctorManage', component: DoctorManage, name: '医生信息管理', meta: { title: '医生团队 · BrainU', requiresAuth: true } }
             ]
         }
     ]
 })
 
-
-// 路由拦截，判断是否需要登录
 router.beforeEach((to, from, next) => {
-    if (to.meta.title) {
-        document.title = to.meta.title;
+    document.title = to.meta.title || 'BrainU 医学影像平台'
+    if (!to.meta.requiresAuth || getToken()) {
+        next()
+        return
     }
-    if (to.path == "/") {
-        next({
-            path: '/getStart',
-            // query: { redirect: to.fullPath }
-        });
-    }
-    if (to.path === '/login') {
-        next();
-    } else {
-        let token = getToken();
-        if (token === null || token === '' || token === undefined) {
-            next('/login');
-        } else {
-            next();
-        }
-    }
+    next({ path: '/login', query: { redirect: to.fullPath } })
+})
 
-});
-
-
-export default router;
-
+export default router

--- a/designSystem/BrainU-frontend/src/views/index.vue
+++ b/designSystem/BrainU-frontend/src/views/index.vue
@@ -1,246 +1,145 @@
 <template>
-  <div class="app-container">
-    <el-container class="operation-wrapper">
-      <el-aside width="200px">
-        <div style="position:fixed; width: 200px; height: 100%;">
-          <span style="font-size:xx-large;"><img class="logoImg" src="../assets/images/logo.png" alt=""></span>
-          <span style="line-height: 160px;"></span>
-          <br>
-          <span style="font-size:small;">Version 1.0.0</span>
-          <br>
-          <span style="font-size:small;">2023年3月15日</span>
-          <br>
-          <p style="line-height: 160px;"></p>
-          <span style="font-size:small;">Copyright(C) 2024</span>
-          <br>
-          <span style="font-size:small;">裴永鹏毕业设计作品</span>
-          <br>
-          <br><br><br><br><br><br><br><br><br><br><br>
-          <span style="font-size:xx-small;">
-            天津市津南区<br>
-            海河教育园区<br>
-            天津中德应用技术大学<br>
-            软件与通信学院<br>
-            2019级软件工程5班<br>
-            <a href="https://beian.miit.gov.cn/#/Integrated/index">津ICP备2024012731号</a>
-          </span>
+  <div class="clinical-layout">
+    <aside class="clinical-sidebar">
+      <div class="brand">
+        <div class="brand-mark"><span></span><span></span></div>
+        <div>
+          <strong>BrainU</strong>
+          <small>医学影像辅助诊断平台</small>
         </div>
-      </el-aside>
-      <el-container>
-        <el-header style="--el-header-padding: 0 0px">
-          <el-menu router :default-active="this.$route.path" mode="horizontal" style="text-align: center;"
-            active-text-color="#409EFF">
-            <el-menu-item style="margin-left: 100px;" index="/getStart">快速开始</el-menu-item>
-            <el-menu-item style="margin-left: 100px;" index="/segment">数据添加</el-menu-item>
-            <el-submenu style="margin-left: 100px;" index="3">
-              <template slot="title">工作空间</template>
-              <el-menu-item index="/newPatients">未诊断患者</el-menu-item>
-              <el-menu-item index="/workSpace">已诊断患者</el-menu-item>
-            </el-submenu>
-            <el-menu-item style="margin-left: 100px;" index="/modelManage">模型信息管理</el-menu-item>
-            <el-menu-item style="margin-left: 100px;" index="/doctorManage">医生信息预览</el-menu-item>
-            <el-dropdown trigger="click" @command="handleCommand">
-              <el-badge style="top: 12px;position: fixed;" :value="number" class="number"
-                :class="number > 0 ? 'flash' : ''" :hidden="number == 0">
-                <el-avatar src="https://cube.elemecdn.com/0/88/03b0d39583f48206768a7534e55bcpng.png"></el-avatar>
-              </el-badge>
-              <el-dropdown-menu slot="dropdown">
-                <el-dropdown-item class="clearfix" command="notifiy">
-                  通知
-                  <el-badge class="mark" :value="number" />
-                </el-dropdown-item>
-                <el-dropdown-item class="clearfix" command="logout">
-                  退出登录
-                  <el-badge class="mark" />
-                </el-dropdown-item>
-              </el-dropdown-menu>
-            </el-dropdown>
-          </el-menu>
-        </el-header>
-        <el-main>
-          <router-view></router-view>
-        </el-main>
-      </el-container>
-    </el-container>
-    <el-drawer title="通知" :visible.sync="notifyDrawer" direction="rtl" size="40%">
-      <el-table :data="notifies" @row-click="rowClick">
-        <el-table-column type="index"></el-table-column>
-        <el-table-column property="context" label="内容" width="300"></el-table-column>
-        <el-table-column property="createTime" label="时间" width="200"></el-table-column>
+      </div>
+
+      <div class="nav-caption">临床工作台</div>
+      <el-menu router :default-active="$route.path" class="clinical-menu" background-color="transparent"
+        text-color="#9fb3c5" active-text-color="#ffffff">
+        <el-menu-item index="/getStart"><i class="el-icon-data-analysis"></i><span>临床概览</span></el-menu-item>
+        <el-menu-item index="/segment"><i class="el-icon-upload2"></i><span>导入影像</span></el-menu-item>
+        <el-submenu index="workspace">
+          <template slot="title"><i class="el-icon-first-aid-kit"></i><span>病例工作区</span></template>
+          <el-menu-item index="/newPatients">待诊断病例</el-menu-item>
+          <el-menu-item index="/workSpace">已诊断病例</el-menu-item>
+        </el-submenu>
+        <div class="nav-caption nav-caption-secondary">系统管理</div>
+        <el-menu-item index="/modelManage"><i class="el-icon-cpu"></i><span>分割模型</span></el-menu-item>
+        <el-menu-item index="/doctorManage"><i class="el-icon-user"></i><span>医生团队</span></el-menu-item>
+      </el-menu>
+
+      <div class="sidebar-footer">
+        <div class="system-state"><span></span>系统服务正常</div>
+        <small>BrainU Clinical v1.0</small>
+      </div>
+    </aside>
+
+    <section class="clinical-content">
+      <header class="clinical-header">
+        <div>
+          <div class="header-eyebrow">BRAIN TUMOR SEGMENTATION</div>
+          <h1>{{ currentTitle }}</h1>
+        </div>
+        <div class="header-actions">
+          <div class="privacy-state"><i class="el-icon-lock"></i> 数据安全连接</div>
+          <el-badge :value="number" :hidden="number === 0" class="notice-badge">
+            <button class="icon-button" type="button" title="通知" @click="notifyDrawer = true">
+              <i class="el-icon-bell"></i>
+            </button>
+          </el-badge>
+          <el-dropdown trigger="click" @command="handleCommand">
+            <div class="doctor-profile">
+              <el-avatar size="small" icon="el-icon-user-solid"></el-avatar>
+              <div><strong>临床医生</strong><small>影像诊断中心</small></div>
+              <i class="el-icon-arrow-down"></i>
+            </div>
+            <el-dropdown-menu slot="dropdown">
+              <el-dropdown-item command="notifiy">查看通知</el-dropdown-item>
+              <el-dropdown-item command="logout" divided>退出登录</el-dropdown-item>
+            </el-dropdown-menu>
+          </el-dropdown>
+        </div>
+      </header>
+
+      <main class="clinical-main"><router-view /></main>
+    </section>
+
+    <el-drawer title="临床通知" :visible.sync="notifyDrawer" direction="rtl" size="420px">
+      <el-table :data="notifies" @row-click="rowClick" class="notice-table">
+        <el-table-column type="index" width="54"></el-table-column>
+        <el-table-column property="context" label="内容"></el-table-column>
+        <el-table-column property="createTime" label="时间" width="160"></el-table-column>
       </el-table>
     </el-drawer>
   </div>
 </template>
+
 <script>
 import { removeToken } from '@/util/auth'
-import { getAllNotify } from "@/api/segment"
+import { getAllNotify } from '@/api/segment'
+
 export default {
-  name: "Index",
-  components: {
-  },
+  name: 'Index',
   data() {
-    return {
-      number: 0,
-      userData: {},
-      notifies: [],
-      notifyDrawer: false
-    };
+    return { number: 0, notifies: [], notifyDrawer: false }
+  },
+  computed: {
+    currentTitle() {
+      return (this.$route.meta && this.$route.meta.title || '临床工作台').split(' · ')[0]
+    }
   },
   mounted() {
     getAllNotify().then(res => {
-      this.notifies = res.data.data;
-      this.number = res.data.data.length;
-    })
-
+      this.notifies = res.data.data || []
+      this.number = this.notifies.length
+    }).catch(() => {})
   },
   methods: {
     rowClick() {
-      this.$router.push({ name: '未诊断患者', path: '/newPatients' }).catch(() => { });
-      this.notifyDrawer = false;
+      this.$router.push('/newPatients').catch(() => {})
+      this.notifyDrawer = false
     },
-
     handleCommand(command) {
-      if (command === 'logout') {
-        this.$confirm('确定退出登录吗？', '提示', {
-          confirmButtonText: '确定',
-          cancelButtonText: '取消',
-          type: 'warning'
-        }).then(() => {
-          removeToken();
-          this.$message({
-            showClose: true,
-            message: '登出成功',
-            type: 'success'
-          });
-          this.$router.push({ name: '登录', path: '/login' }).catch(() => { });
-        }).catch(() => {
-          this.$message({
-            type: 'info',
-            message: '已登出系统'
-          });
-        });
-      } else if (command == 'notifiy') {
-        this.notifyDrawer = true;
+      if (command === 'notifiy') {
+        this.notifyDrawer = true
+        return
       }
+      if (command !== 'logout') return
+      this.$confirm('确定退出当前登录吗？', '退出登录', {
+        confirmButtonText: '退出', cancelButtonText: '取消', type: 'warning'
+      }).then(() => {
+        removeToken()
+        this.$router.push('/login')
+      }).catch(() => {})
     }
   }
-};
+}
 </script>
-<style>
-.item {
-  margin-top: 20px;
-  margin-right: 35px;
-}
-
-.el-menu {
-  width: 100%;
-  display: inline-block;
-  align-items: center;
-  /* 垂直居中 */
-  justify-content: center;
-  /* 水平居中 */
-}
-
-.el-header,
-.el-footer {
-  /* background-color: #B3C0D1; */
-  color: #333;
-  text-align: center;
-  line-height: 60px;
-  /* position: fixed; */
-  width: 100%;
-  padding: 0 0px;
-}
-
-.el-main {
-  color: #333;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, .12), 0 0 6px rgba(0, 0, 0, .04);
-  min-height: 100%;
-  overflow-y: scroll;
-}
-
-html,
-body,
-.el-container {
-  /*设置内部填充为0，几个布局元素之间没有间距*/
-  padding: 0px;
-  /*外部间距也是如此设置*/
-  margin: 0px;
-  /*统一设置高度为100%*/
-  height: 100%;
-}
-
-.el-container:nth-child(5) .el-aside,
-.el-container:nth-child(6) .el-aside {
-  line-height: 260px;
-}
-
-.el-container:nth-child(7) .el-aside {
-  line-height: 320px;
-}
-
-.el-header,
-.el-footer {
-  color: #333;
-  text-align: center;
-  line-height: 60px;
-}
-
-.el-aside {
-  color: #333;
-  text-align: center;
-  height: 100%;
-}
-
-
-.logoImg {
-  margin-top: 50px;
-  width: 150px;
-  height: 90px;
-}
-</style>
 
 <style lang="scss">
-.operation-wrapper {
-  width: 100% !important;
-
-  .el-header {
-    height: 61px;
-  }
-
-  .el-aside {
-    width: 200px;
-    height: calc(100vh - 61px); //61px为顶部header盒子高度
-    overflow-y: auto;
-  }
-
-  .el-main {
-    padding: 0px 16px !important;
-    height: calc(100vh - 61px); //61px为顶部header盒子高度
-    overflow-y: auto;
-  }
-}
-</style>
-
-
-<style scoped>
-/*闪烁动画*/
-@keyframes twinkle {
-  from {
-    opacity: 1.0;
-  }
-
-  50% {
-    opacity: 0.4;
-  }
-
-  to {
-    opacity: 1.0;
-  }
-}
-
-.flash /deep/ .el-badge__content {
-  animation: twinkle 2s;
-  animation-iteration-count: infinite;
-}
+.clinical-layout { min-height: 100vh; display: flex; background: #f3f7f9; color: #1a2b3b; }
+.clinical-sidebar { position: fixed; inset: 0 auto 0 0; z-index: 20; width: 248px; display: flex; flex-direction: column; background: #0c2438; box-shadow: 12px 0 30px rgba(7, 31, 49, .08); }
+.brand { height: 92px; display: flex; align-items: center; gap: 13px; padding: 0 24px; border-bottom: 1px solid rgba(255,255,255,.08); color: white; }
+.brand strong { display:block; font: 700 24px/1.1 Inter, sans-serif; letter-spacing: -.5px; }
+.brand small { display:block; margin-top: 5px; color:#8fa9bc; font-size: 11px; letter-spacing:.5px; }
+.brand-mark { position: relative; width: 36px; height: 36px; border: 1px solid rgba(72, 213, 205, .5); border-radius: 11px; background: rgba(40, 177, 173, .12); }
+.brand-mark span { position:absolute; background:#48d5cd; border-radius:2px; }
+.brand-mark span:first-child { width:18px; height:5px; left:8px; top:15px; }
+.brand-mark span:last-child { width:5px; height:18px; left:15px; top:8px; }
+.nav-caption { padding: 25px 25px 9px; color:#66849a; font-size:10px; font-weight:700; letter-spacing:1.6px; }
+.nav-caption-secondary { padding-top: 20px; }
+.clinical-menu { border:0 !important; }
+.clinical-menu .el-menu-item, .clinical-menu .el-submenu__title { height:48px; line-height:48px; margin:3px 12px; padding-left:14px !important; border-radius:8px; }
+.clinical-menu .el-menu-item i, .clinical-menu .el-submenu__title i { color:#7895aa; margin-right:12px; }
+.clinical-menu .el-menu-item:hover, .clinical-menu .el-submenu__title:hover { background:rgba(255,255,255,.055) !important; }
+.clinical-menu .el-menu-item.is-active { background:linear-gradient(90deg, #158f91, #13777e) !important; box-shadow:0 8px 18px rgba(0,0,0,.16); }
+.clinical-menu .el-menu-item.is-active i { color:#fff; }
+.clinical-menu .el-submenu .el-menu-item { min-width:auto; padding-left:50px !important; background:transparent !important; }
+.sidebar-footer { margin-top:auto; padding:20px 24px 24px; border-top:1px solid rgba(255,255,255,.08); color:#6f8da2; }
+.system-state { margin-bottom:8px; color:#9fb6c6; font-size:12px; }.system-state span { display:inline-block; width:7px; height:7px; margin-right:8px; border-radius:50%; background:#36c99b; box-shadow:0 0 0 4px rgba(54,201,155,.12); }
+.clinical-content { width:calc(100% - 248px); min-width:0; margin-left:248px; }
+.clinical-header { position:sticky; top:0; z-index:15; height:91px; display:flex; align-items:center; justify-content:space-between; padding:0 34px; background:rgba(255,255,255,.96); border-bottom:1px solid #e2eaee; backdrop-filter:blur(10px); }
+.clinical-header h1 { margin:5px 0 0; font-size:21px; font-weight:650; letter-spacing:-.3px; }.header-eyebrow { color:#7b929f; font-size:9px; font-weight:700; letter-spacing:1.5px; }
+.header-actions { display:flex; align-items:center; gap:18px; }.privacy-state { color:#63808d; font-size:12px; }.privacy-state i { color:#15918e; margin-right:6px; }
+.icon-button { width:38px; height:38px; border:1px solid #dce7eb; border-radius:10px; background:#fff; color:#506b78; cursor:pointer; }.icon-button:hover { color:#13898a; border-color:#8dc9c7; }
+.doctor-profile { display:flex; align-items:center; gap:10px; cursor:pointer; padding-left:3px; }.doctor-profile .el-avatar { background:#dcefee; color:#167f7f; }.doctor-profile strong,.doctor-profile small { display:block; }.doctor-profile strong { font-size:12px; }.doctor-profile small { margin-top:3px; color:#8ba0aa; font-size:10px; }.doctor-profile > i { color:#91a3ac; }
+.clinical-main { min-height:calc(100vh - 92px); padding:26px 30px 34px; box-sizing:border-box; }
+.notice-table { cursor:pointer; }
+@media (max-width: 1050px) { .clinical-sidebar { width:210px; }.clinical-content { width:calc(100% - 210px); margin-left:210px; }.privacy-state { display:none; }.clinical-header { padding:0 22px; }.clinical-main { padding:20px; } }
 </style>

--- a/designSystem/BrainU-frontend/src/views/workSpace/components/js/TBaseObject.js
+++ b/designSystem/BrainU-frontend/src/views/workSpace/components/js/TBaseObject.js
@@ -57,3 +57,9 @@ export function setYPosition(num) {
 export function setZPosition(num) {
     box2.position.z += num
 }
+
+export function resetPositions() {
+    box.position.set(0, 0, 0)
+    box1.position.set(0, 0, 0)
+    box2.position.set(0, 0, 0)
+}

--- a/designSystem/BrainU-frontend/src/views/workSpace/components/js/TEngine.js
+++ b/designSystem/BrainU-frontend/src/views/workSpace/components/js/TEngine.js
@@ -2,150 +2,121 @@ import { WebGLRenderer, Scene, PerspectiveCamera, Vector3, Raycaster, Vector2 } 
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 import { TransformControls } from 'three/examples/jsm/controls/TransformControls'
 
-
 export class ThreeEngine {
-
-    dom = null; // 挂载的 DOM
-    scene = null; // 场景
-
     constructor(dom) {
-        console.log(dom);
-        // 创建渲染器
-        let renderer = new WebGLRenderer({
-            antialias: true,  // 开启抗锯齿
-        })
-        dom.appendChild(renderer.domElement)  // 将渲染器挂载到dom
-        renderer.setSize(dom.offsetWidth, dom.offsetHeight, true)
-
-        let scene = new Scene()  // 实例化场景
-
-        let camera = new PerspectiveCamera(45, dom.offsetWidth / dom.offsetHeight, 1, 1000)  // 实例化相机
-        camera.position.set(250, 0, 250) // 设置相机位置
-        camera.lookAt(new Vector3(0, 0, 0))  // 设置相机看先中心点
-        camera.up = new Vector3(0, 1, 0)  // 设置相机角度
-
-        // renderer.setClearColor('rgb(239, 70, 1)')  // 设置渲染器的颜色
-        // renderer.clearColor()   // 清空颜色
-        renderer.render(scene, camera)  // 渲染器渲染场景和相机
-
-        new OrbitControls(camera, renderer.domElement)
-
-
-        // 初始化射线发射器
-        let raycaster = new Raycaster()
-        // 初始化变换控制器
-        let transformControls = new TransformControls(camera, renderer.domElement)
-        scene.add(transformControls) // 将变换控制器添加至场景
-
-        let transing = false
-        transformControls.addEventListener("mouseDown", event => {
-            console.log(event)
-            transing = true
-        })
-
-        // 初始化鼠标位置
-        let mouse = new Vector2()
-        let x = 0; let y = 0; let width = 0; let height = 0
-
-        renderer.domElement.addEventListener("mousemove", event => {
-            x = event.offsetX
-            y = event.offsetY
-            width = renderer.domElement.offsetWidth
-            height = renderer.domElement.offsetHeight
-            mouse.x = x / width * 2 - 1
-            mouse.y = -y * 2 / height + 1
-
-            raycaster.setFromCamera(mouse, camera)  // 配置射线发射器
-            scene.remove(transformControls)  // 移除变换控制器
-            const intersection = raycaster.intersectObjects(scene.children)
-            if (intersection.length) {
-                const object = intersection[0].object
-                if (object !== this.cacheObject) {  // 如果当前物体不等于缓存的物体
-                    if (this.cacheObject) { // 如果有缓存物体先执行之前物体的离开事件
-                        this.cacheObject.dispatchEvent({
-                            type: 'mouseleave'
-                        })
-                    }
-                    object.dispatchEvent({  // 添加当前物体进入事件
-                        type: 'mouseenter'
-                    })
-                } else if (object === this.cacheObject) {  // 如果当前物体等于缓存的物体
-                    object.dispatchEvent({  // 执行移动事件
-                        type: 'mousemove'
-                    })
-                }
-                this.cacheObject = object
-            } else {
-                if (this.cacheObject) {  // 如果有缓存物体就先执行离开事件
-                    this.cacheObject.dispatchEvent({
-                        type: 'mouseleave'
-                    })
-                }
-                this.cacheObject = null
-            }
-        })
-
-        // 点击事件
-        renderer.domElement.addEventListener("click", event => {
-            console.log(event)
-            if (transing) {
-                transing = false
-                return
-            }
-            scene.remove(transformControls) // 移除变换控制器
-            transformControls.enabled = false // 停用变换控制器
-            raycaster.setFromCamera(mouse, camera)  // 配置射线发射器，传递鼠标和相机对象
-            const intersection = raycaster.intersectObjects(scene.children) // 获取射线发射器捕获的模型列表，传进去场景中所以模型，穿透的会返回我们
-            if (intersection.length) {
-                const object = intersection[0].object  // 获取第一个模型
-                scene.add(transformControls) // 添加变换控制器
-                transformControls.enabled = true // 启用变换控制器
-                transformControls.attach(object)
-            }
-        })
-
-
-        // 监听变换控制器模式更改
-        document.addEventListener("keyup", event => {
-            if (transformControls.enabled) {  // 变换控制器为启用状态执行
-                if (event.key === 'e') { // 鼠标按下e键，模式改为缩放
-                    transformControls.mode = 'scale'
-                    return false
-                }
-                if (event.key === 'r') { // 鼠标按下r键，模式改为旋转
-                    transformControls.mode = 'rotate'
-                    return false
-                }
-                if (event.key === 't') { // 鼠标按下t键，模式改为平移
-                    transformControls.mode = 'translate'
-                    return false
-                }
-            }
-        })
-
-
-
-
-        // 逐帧渲染threejs
-        let animate = () => {
-            renderer.render(scene, camera)  // 渲染器渲染场景和相机
-            requestAnimationFrame(animate);
-        }
-        animate()
-
         this.dom = dom
-        this.scene = scene
-        console.log("渲染完成")
+        this.disposed = false
+        this.animationId = null
+        this.cacheObject = null
+        this.mouse = new Vector2()
+        this.raycaster = new Raycaster()
+
+        this.renderer = new WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' })
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2))
+        this.renderer.setClearColor(0x000000, 0)
+        dom.appendChild(this.renderer.domElement)
+
+        this.scene = new Scene()
+        this.camera = new PerspectiveCamera(45, 1, 1, 1000)
+        this.camera.position.set(250, 0, 250)
+        this.camera.lookAt(new Vector3(0, 0, 0))
+        this.camera.up = new Vector3(0, 1, 0)
+
+        this.controls = new OrbitControls(this.camera, this.renderer.domElement)
+        this.controls.enableDamping = true
+        this.controls.dampingFactor = 0.08
+
+        this.transformControls = new TransformControls(this.camera, this.renderer.domElement)
+        this.transformControls.enabled = false
+        this.scene.add(this.transformControls)
+
+        this.handlePointerMove = this.onPointerMove.bind(this)
+        this.handleClick = this.onClick.bind(this)
+        this.handleKeyUp = this.onKeyUp.bind(this)
+        this.renderer.domElement.addEventListener('pointermove', this.handlePointerMove)
+        this.renderer.domElement.addEventListener('click', this.handleClick)
+        document.addEventListener('keyup', this.handleKeyUp)
+
+        this.handleResize = this.resize.bind(this)
+        this.resizeObserver = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(this.handleResize) : null
+        if (this.resizeObserver) this.resizeObserver.observe(dom)
+        else window.addEventListener('resize', this.handleResize)
+
+        this.resize()
+        this.animate()
     }
 
-    /**
-     * 向场景中添加模型
-     * @param  {...any} object 模型列表
-     */
-    addObject(...object) {
-        object.forEach(elem => {
-            this.scene.add(elem)
-        })
+    resize() {
+        if (this.disposed || !this.dom) return
+        const width = Math.max(this.dom.clientWidth, 1)
+        const height = Math.max(this.dom.clientHeight, 1)
+        this.camera.aspect = width / height
+        this.camera.updateProjectionMatrix()
+        this.renderer.setSize(width, height, false)
     }
 
+    getIntersections(event) {
+        const rect = this.renderer.domElement.getBoundingClientRect()
+        this.mouse.x = ((event.clientX - rect.left) / rect.width) * 2 - 1
+        this.mouse.y = -((event.clientY - rect.top) / rect.height) * 2 + 1
+        this.raycaster.setFromCamera(this.mouse, this.camera)
+        const selectable = this.scene.children.filter(item => item !== this.transformControls)
+        return this.raycaster.intersectObjects(selectable, true)
+    }
+
+    onPointerMove(event) {
+        const hit = this.getIntersections(event)[0]
+        const object = hit && hit.object
+        if (object === this.cacheObject) return
+        if (this.cacheObject) this.cacheObject.dispatchEvent({ type: 'mouseleave' })
+        if (object) object.dispatchEvent({ type: 'mouseenter' })
+        this.cacheObject = object || null
+    }
+
+    onClick(event) {
+        const hit = this.getIntersections(event)[0]
+        if (!hit) {
+            this.transformControls.detach()
+            this.transformControls.enabled = false
+            return
+        }
+        this.transformControls.enabled = true
+        this.transformControls.attach(hit.object)
+    }
+
+    onKeyUp(event) {
+        if (!this.transformControls.enabled) return
+        const modes = { e: 'scale', r: 'rotate', t: 'translate' }
+        if (modes[event.key.toLowerCase()]) this.transformControls.setMode(modes[event.key.toLowerCase()])
+    }
+
+    animate() {
+        if (this.disposed) return
+        this.animationId = requestAnimationFrame(() => this.animate())
+        this.controls.update()
+        this.renderer.render(this.scene, this.camera)
+    }
+
+    addObject(...objects) {
+        objects.forEach(object => this.scene.add(object))
+    }
+
+    dispose() {
+        if (this.disposed) return
+        this.disposed = true
+        if (this.animationId) cancelAnimationFrame(this.animationId)
+        if (this.resizeObserver) this.resizeObserver.disconnect()
+        else window.removeEventListener('resize', this.handleResize)
+        this.renderer.domElement.removeEventListener('pointermove', this.handlePointerMove)
+        this.renderer.domElement.removeEventListener('click', this.handleClick)
+        document.removeEventListener('keyup', this.handleKeyUp)
+        this.transformControls.detach()
+        this.transformControls.dispose()
+        this.controls.dispose()
+        this.renderer.dispose()
+        this.renderer.forceContextLoss()
+        if (this.renderer.domElement.parentNode) this.renderer.domElement.parentNode.removeChild(this.renderer.domElement)
+        this.scene.clear()
+        this.dom = null
+    }
 }

--- a/designSystem/BrainU-frontend/src/views/workSpace/components/sliceViewport.vue
+++ b/designSystem/BrainU-frontend/src/views/workSpace/components/sliceViewport.vue
@@ -1,0 +1,105 @@
+<template>
+  <section class="slice-viewport" @wheel.prevent="handleWheel">
+    <header class="viewport-header">
+      <div><span class="series-dot"></span><strong>{{ title }}</strong><small>{{ subtitle }}</small></div>
+      <div class="viewport-actions">
+        <button type="button" :title="segmented ? '查看原始影像' : '查看分割结果'" @click.stop="$emit('toggle')">
+          <i :class="segmented ? 'el-icon-view' : 'el-icon-magic-stick'"></i>
+        </button>
+        <button type="button" title="下载当前切片" @click.stop="$emit('download')"><i class="el-icon-download"></i></button>
+      </div>
+    </header>
+
+    <div class="image-stage">
+      <div v-if="!currentUrl" class="empty-state"><i class="el-icon-picture-outline"></i><span>暂无切片</span></div>
+      <img v-else :key="currentUrl" :src="currentUrl" :alt="title" @load="onImageLoaded" @error="onImageError">
+      <div v-if="loading && currentUrl" class="image-loading"><i class="el-icon-loading"></i></div>
+      <span class="orientation orientation-top">{{ orientation.top }}</span>
+      <span class="orientation orientation-right">{{ orientation.right }}</span>
+      <span class="orientation orientation-bottom">{{ orientation.bottom }}</span>
+      <span class="orientation orientation-left">{{ orientation.left }}</span>
+      <span class="crosshair crosshair-x" :style="{ top: crosshairY + '%' }"></span>
+      <span class="crosshair crosshair-y" :style="{ left: crosshairX + '%' }"></span>
+    </div>
+
+    <footer class="viewport-footer">
+      <el-slider :value="safeIndex" :min="0" :max="maxIndex" :show-tooltip="false" @input="updateIndex" />
+      <span>{{ displayIndex }} / {{ urls.length }}</span>
+    </footer>
+  </section>
+</template>
+
+<script>
+export default {
+  name: 'SliceViewport',
+  props: {
+    title: { type: String, required: true },
+    subtitle: { type: String, default: '' },
+    urls: { type: Array, default: () => [] },
+    value: { type: Number, default: 0 },
+    segmented: { type: Boolean, default: true },
+    crosshairX: { type: Number, default: 50 },
+    crosshairY: { type: Number, default: 50 },
+    orientation: { type: Object, default: () => ({ top: 'A', right: 'L', bottom: 'P', left: 'R' }) }
+  },
+  data() { return { loading: false, preloadCache: new Map() } },
+  computed: {
+    maxIndex() { return Math.max(this.urls.length - 1, 0) },
+    safeIndex() { return Math.min(Math.max(this.value, 0), this.maxIndex) },
+    displayIndex() { return this.urls.length ? this.safeIndex + 1 : 0 },
+    currentUrl() { return this.urls[this.safeIndex] || '' }
+  },
+  watch: {
+    currentUrl: {
+      immediate: true,
+      handler(url) {
+        this.loading = Boolean(url)
+        this.preloadNeighbours()
+      }
+    },
+    urls() {
+      this.preloadCache.clear()
+      this.preloadNeighbours()
+    }
+  },
+  beforeDestroy() { this.preloadCache.clear() },
+  methods: {
+    updateIndex(index) { this.$emit('input', index) },
+    handleWheel(event) {
+      if (!this.urls.length) return
+      this.updateIndex(Math.min(this.maxIndex, Math.max(0, this.safeIndex + (event.deltaY > 0 ? 1 : -1))))
+    },
+    onImageLoaded() { this.loading = false },
+    onImageError() { this.loading = false },
+    preloadNeighbours() {
+      if (typeof Image === 'undefined') return
+      ;[-2, -1, 1, 2].forEach(offset => {
+        const url = this.urls[this.safeIndex + offset]
+        if (!url || this.preloadCache.has(url)) return
+        const image = new Image()
+        image.decoding = 'async'
+        image.src = url
+        this.preloadCache.set(url, image)
+      })
+      // Keep the cache deliberately small so long studies do not accumulate
+      // decoded images in memory while the user scrolls through a series.
+      if (this.preloadCache.size > 12) {
+        const keep = new Set(this.urls.slice(Math.max(0, this.safeIndex - 3), this.safeIndex + 4))
+        Array.from(this.preloadCache.keys()).forEach(url => { if (!keep.has(url)) this.preloadCache.delete(url) })
+      }
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.slice-viewport { min-width:0; display:flex; flex-direction:column; overflow:hidden; background:#071018; border:1px solid #203441; border-radius:8px; box-shadow:0 8px 22px rgba(0,0,0,.18); }
+.viewport-header { height:42px; display:flex; align-items:center; justify-content:space-between; padding:0 12px; color:#d8e5eb; background:#101f29; border-bottom:1px solid #203441; }
+.viewport-header > div:first-child { display:flex; align-items:center; gap:8px; }.viewport-header strong { font-size:12px; }.viewport-header small { color:#698391; font-size:10px; }.series-dot { width:6px; height:6px; border-radius:50%; background:#33c6bc; box-shadow:0 0 0 3px rgba(51,198,188,.12); }
+.viewport-actions { display:flex; gap:4px; }.viewport-actions button { width:28px; height:28px; border:0; border-radius:5px; color:#8fa7b3; background:transparent; cursor:pointer; }.viewport-actions button:hover { color:#45d2c8; background:#1a303c; }
+.image-stage { position:relative; flex:1; min-height:0; display:flex; align-items:center; justify-content:center; overflow:hidden; background:#03070a; }.image-stage img { width:100%; height:100%; object-fit:contain; user-select:none; -webkit-user-drag:none; }.empty-state { display:flex; flex-direction:column; align-items:center; gap:8px; color:#40535d; font-size:11px; }.empty-state i { font-size:25px; }
+.image-loading { position:absolute; inset:0; display:grid; place-items:center; color:#45d2c8; background:rgba(3,7,10,.38); }.orientation { position:absolute; z-index:2; color:#e8c75d; font:600 10px/1 monospace; text-shadow:0 1px 3px #000; }.orientation-top { top:9px; left:50%; }.orientation-right { right:9px; top:50%; }.orientation-bottom { bottom:9px; left:50%; }.orientation-left { left:9px; top:50%; }
+.crosshair { position:absolute; z-index:1; pointer-events:none; opacity:.55; }.crosshair-x { left:0; right:0; border-top:1px dashed #35a9df; }.crosshair-y { top:0; bottom:0; border-left:1px dashed #35a9df; }
+.viewport-footer { height:38px; display:flex; align-items:center; gap:12px; padding:0 12px; color:#78909c; background:#101f29; border-top:1px solid #203441; font:10px/1 monospace; }.viewport-footer .el-slider { flex:1; }
+.viewport-footer ::v-deep .el-slider__runway { height:3px; margin:14px 0; background:#263b47; }.viewport-footer ::v-deep .el-slider__bar { height:3px; background:#36bdb6; }.viewport-footer ::v-deep .el-slider__button { width:10px; height:10px; border:2px solid #36bdb6; background:#071018; }
+</style>

--- a/designSystem/BrainU-frontend/src/views/workSpace/components/tumorView.vue
+++ b/designSystem/BrainU-frontend/src/views/workSpace/components/tumorView.vue
@@ -1,600 +1,191 @@
 <template>
-    <div>
-        <el-dialog :visible.sync="dialogVisible" width="70%" :before-close="handleClose" :close-on-click-modal="false"
-            :close-on-press-escape="false" top="0vh" :fullscreen="false" style="position: absolute; z-index: 9999;"
-            @close="dialogClose()" @open="open()" destroy-on-close>
-            <div style="margin-left: 20vh; width: 100vh; height: 100vh;">
-                <div class="out1" id="seDiv">
-                    <span class="postitonText" style="margin-left: 20vh;">A</span>
-                    <span class="postitonText" style="margin-top: 20vh;">R</span>
-                    <span class="postitonText" style="margin-left: 39vh; margin-top: 20vh;">L</span>
-                    <span class="postitonText" style="margin-left: 20vh; margin-top: 38vh;">P</span>
-                    <div style="position: absolute; z-index: 999; width: 40vh; height: 40vh;"
-                        @mousewheel="handleMouseWheel1">
-                        <div class="coordinateX" id="seX" :style="`bottom:${seIndex}px`"></div>
-                        <div class="coordinateY" id="seY"></div>
-                    </div>
-                    <div ref="scrollDiv1" class="div1" v-for="(item, key) in semgentUrls" :key="'se-' + key">
-                        <el-image class="image1" :src="item" v-show="seIndex === key">
-                        </el-image>
-                    </div>
-                    <el-link v-if="isSeRender" id="selink" :underline="false" icon="el-icon-view"
-                        style="margin-left: 41.2vh;" @click="previewPic('se')"></el-link>
-                    <el-link v-if="!isSeRender" id="selink" :underline="false" icon="el-icon-magic-stick"
-                        style="margin-left: 41.2vh;" @click="previewPic('se')"></el-link>
-                    <el-link id="selink" :underline="false" icon="el-icon-camera-solid" style="margin-left: 41.2vh;"
-                        @click="downloadSnap('se')"></el-link>
-                    <el-slider id="seSlider" class="sliderMain" :max="semgentLen" :show-tooltip="false" v-model="seIndex"
-                        vertical height="35vh" style="margin-left: 39vh;" @input="sliderchange1">
-                    </el-slider>
-                    <span class="text">{{ seIndex + 1 }} of {{ semgentUrls.length }}</span>
-                </div>
-                <div class="out2">
-                    <span class="postitonText" style="margin-left: 20vh;">S</span>
-                    <span class="postitonText" style="margin-top: 20vh;">A</span>
-                    <span class="postitonText" style="margin-left: 39vh; margin-top: 20vh;">I</span>
-                    <span class="postitonText" style="margin-left: 20vh; margin-top: 38vh;">P</span>
-                    <div style="position: absolute; z-index: 999; width: 40vh; height: 40vh;"
-                        @mousewheel="handleMouseWheel3">
-                        <div class="coordinateX" id="sideX"></div>
-                        <div class="coordinateY" id="sideY"></div>
-                    </div>
-                    <div class="div2" v-for="(item, key) in sideUrls" :key="'side' + key">
-                        <el-image class="image2" :src="item" v-show="sideIndex == key">
-                        </el-image>
-                    </div>
-                    <el-link v-if="isSideRender" id="selink" :underline="false" icon="el-icon-view"
-                        style="margin-left: 41.2vh;" @click="previewPic('seSide')"></el-link>
-                    <el-link v-if="!isSideRender" id="selink" :underline="false" icon="el-icon-magic-stick"
-                        style="margin-left: 41.2vh;" @click="previewPic('seSide')"></el-link>
-                    <el-link id="sidelink" :underline="false" icon="el-icon-camera-solid" style="margin-left: 41.2vh;"
-                        @click="downloadSnap('seSide')"></el-link>
-                    <el-slider class="sliderMain" :max="sideLen" :show-tooltip="false" v-model="sideIndex" vertical
-                        height="35vh" style="margin-left: 39vh;" @input="sliderchange3">
-                    </el-slider>
-                    <span class="text">{{ sideIndex + 1 }} of {{ sideUrls.length }}</span>
-                </div>
-                <div class="out3">
-                    <span class="postitonText" style="margin-left: 20vh;">S</span>
-                    <span class="postitonText" style="margin-top: 20vh;">R</span>
-                    <span class="postitonText" style="margin-left: 39vh; margin-top: 20vh;">L</span>
-                    <span class="postitonText" style="margin-left: 20vh; margin-top: 38vh;">I</span>
-                    <div style="position: absolute; z-index: 999; width: 40vh; height: 40vh;"
-                        @mousewheel="handleMouseWheel2">
-                        <div class="coordinateX" id="fontX"></div>
-                        <div class="coordinateY" id="fontY"></div>
-                    </div>
-                    <div class="div3" v-for="(item, key) in fontUrls" :key="'font-' + key">
-                        <el-image class="image3" :src="item" v-show="fontIndex == key">
-                        </el-image>
-                    </div>
-                    <el-link v-if="isFontRender" id="selink" :underline="false" icon="el-icon-view"
-                        style="margin-left: 41.2vh;" @click="previewPic('seFont')"></el-link>
-                    <el-link v-if="!isFontRender" id="selink" :underline="false" icon="el-icon-magic-stick"
-                        style="margin-left: 41.2vh;" @click="previewPic('seFont')"></el-link>
-                    <el-link id="fontlink" :underline="false" icon="el-icon-camera-solid" style="margin-left: 41.2vh;"
-                        @click="downloadSnap('seFont')"></el-link>
-                    <el-slider class="sliderMain" :max="fontLen" :show-tooltip="false" v-model="fontIndex" vertical
-                        height="35vh" style="margin-left: 39vh;" @input="sliderchange2">
-                    </el-slider>
-                    <span class="text">{{ fontIndex + 1 }} of {{ fontUrls.length }}</span>
-                </div>
-                <div class="out4">
-                    <div class="div4" ref="threeTarget">
-                    </div>
-                </div>
-            </div>
-        </el-dialog>
+  <el-dialog :visible.sync="dialogVisible" custom-class="medical-viewer-dialog" width="96%" top="2vh"
+    :close-on-click-modal="false" append-to-body @opened="initThreeScene" @closed="releaseViewer">
+    <template slot="title">
+      <div class="viewer-titlebar">
+        <div class="viewer-brand"><span class="viewer-logo">B</span><div><strong>BrainU 影像工作站</strong><small>多平面重建与肿瘤分割预览</small></div></div>
+        <div class="patient-summary">
+          <span><small>患者</small>{{ patient.patientName || '未命名' }}</span>
+          <span><small>病例号</small>{{ patient.id || '--' }}</span>
+          <span><small>影像序列</small>MRI · MPR</span>
+        </div>
+      </div>
+    </template>
+
+    <div class="viewer-toolbar">
+      <div class="tool-group"><button title="窗宽窗位"><i class="el-icon-s-operation"></i><span>窗宽窗位</span></button><button title="测量"><i class="el-icon-data-line"></i><span>测量</span></button><button title="复位"><i class="el-icon-refresh-left"></i><span>复位</span></button></div>
+      <div class="viewer-legend"><span class="legend-segment"></span>分割结果 <span class="legend-crosshair"></span>定位线</div>
     </div>
+
+    <div v-loading="studyLoading" element-loading-text="正在读取影像序列…" element-loading-background="rgba(5, 14, 20, .88)" class="viewer-grid">
+      <slice-viewport title="轴位" subtitle="AXIAL" :urls="semgentUrls" v-model="seIndex" :segmented="isSeRender"
+        :crosshair-x="slicePercent(sideIndex, sideUrls)" :crosshair-y="slicePercent(fontIndex, fontUrls)"
+        :orientation="{ top:'A', right:'L', bottom:'P', left:'R' }" @toggle="toggleSeries('se')" @download="downloadCurrent('se')" />
+      <slice-viewport title="矢状位" subtitle="SAGITTAL" :urls="sideUrls" v-model="sideIndex" :segmented="isSideRender"
+        :crosshair-x="slicePercent(fontIndex, fontUrls)" :crosshair-y="100 - slicePercent(seIndex, semgentUrls)"
+        :orientation="{ top:'S', right:'I', bottom:'I', left:'A' }" @toggle="toggleSeries('seSide')" @download="downloadCurrent('seSide')" />
+      <slice-viewport title="冠状位" subtitle="CORONAL" :urls="fontUrls" v-model="fontIndex" :segmented="isFontRender"
+        :crosshair-x="slicePercent(sideIndex, sideUrls)" :crosshair-y="100 - slicePercent(seIndex, semgentUrls)"
+        :orientation="{ top:'S', right:'L', bottom:'I', left:'R' }" @toggle="toggleSeries('seFont')" @download="downloadCurrent('seFont')" />
+
+      <section class="volume-viewport">
+        <header><div><span></span><strong>三维定位</strong><small>3D LOCALIZER</small></div><em>拖拽旋转 · 滚轮缩放</em></header>
+        <div ref="threeTarget" class="three-stage"></div>
+        <footer><span><i></i>X 轴</span><span><i></i>Y 轴</span><span><i></i>Z 轴</span></footer>
+      </section>
+    </div>
+
+    <div class="viewer-statusbar"><span><i class="status-online"></i>影像数据已加密加载</span><span>滚轮浏览切片 · 相邻 2 帧智能预取</span><span>{{ totalSlices }} 张切片</span></div>
+  </el-dialog>
 </template>
+
 <script>
-import { getPicUrl, downloadPic, changePicUrl } from "@/api/segment";
+import { getPicUrl, downloadPic, changePicUrl } from '@/api/segment'
+import SliceViewport from './sliceViewport'
 import { ThreeEngine } from './js/TEngine'
 import { allLights } from './js/TLights'
-import { allBaseObject, setXPosition, setYPosition, setZPosition } from './js/TBaseObject'
+import { allBaseObject, resetPositions, setXPosition, setYPosition, setZPosition } from './js/TBaseObject'
+
 export default {
-    name: 'TumorView',
-    components: {
-
-    },
-    mixins: [],
-    props: {
-
-    },
-    data() {
-        return {
-            dialogVisible: false,
-            timer: null,
-            newPic: 0,
-            seIndex: 77,
-            fontIndex: 120,
-            sideIndex: 120,
-            semgentUrls: [],
-            fontUrls: [],
-            sideUrls: [],
-            semgentLen: 0,
-            fontLen: 0,
-            sideLen: 0,
-            rootPath: '',
-            fullscreenLoading: false,
-            isSeRender: true,
-            isSideRender: true,
-            isFontRender: true,
-            ThreeEngine: null
-        }
-    },
-    computed: {
-
-    },
-    watch: {
-        seIndex(value, oldValue) {
-            // 第一个参数为新值，第二个参数为旧值，不能调换顺序
-            if (this.seIndex !== 77) {
-                setYPosition(oldValue - value)
-            }
-        },
-        fontIndex(value, oldValue) {
-            // 第一个参数为新值，第二个参数为旧值，不能调换顺序
-            if (this.fontIndex !== 120) {
-                setXPosition(oldValue - value)
-            }
-        },
-        sideIndex(value, oldValue) {
-            // 第一个参数为新值，第二个参数为旧值，不能调换顺序
-            if (this.sideIndex !== 120) {
-                setZPosition(oldValue - value)
-            }
-        }
-    },
-    mounted() {
-
-
-    },
-    methods: {
-        openFullScreen() {
-            let loading = this.$loading({
-                lock: true,
-                text: '数据加载中，请稍后...',
-                spinner: 'el-icon-loading',
-                background: 'rgba(255, 255, 255, 255)'
-            });
-            setTimeout(() => {
-                this.dialogVisible = true;
-            }, 1000);
-            setTimeout(() => {
-                console.log("调用")
-                loading.close();
-                this.$message({
-                    showClose: true,
-                    message: '加载完成',
-                    type: 'success'
-                });
-            }, 10000);
-
-        },
-        previewPic(key) {
-            let tmpPath = ""
-            let loading = this.$loading({
-                lock: true,
-                text: '数据加载中，请稍后...',
-                spinner: 'el-icon-loading',
-                background: 'rgba(255, 255, 255, 255)'
-            });
-            if (key === 'se') {
-                if (this.isSeRender) {
-                    tmpPath = this.rootPath + "/original"
-                    this.isSeRender = false
-                } else {
-                    tmpPath = this.rootPath
-                    this.isSeRender = true
-                }
-                changePicUrl(tmpPath, key).then(res => {
-                    this.semgentUrls = res.data.data;
-                })
-            } else if (key === 'seSide') {
-                if (this.isSideRender) {
-                    tmpPath = this.rootPath + "/original"
-                    this.isSideRender = false
-                } else {
-                    tmpPath = this.rootPath
-                    this.isSideRender = true
-                }
-                changePicUrl(tmpPath, key).then(res => {
-                    this.sideUrls = res.data.data;
-                })
-            } else if (key === 'seFont') {
-                if (this.isFontRender) {
-                    tmpPath = this.rootPath + "/original"
-                    this.isFontRender = false
-                } else {
-                    tmpPath = this.rootPath
-                    this.isFontRender = true
-                }
-                changePicUrl(tmpPath, key).then(res => {
-                    this.fontUrls = res.data.data;
-                })
-            }
-            setTimeout(() => {
-                console.log("调用")
-                loading.close();
-                this.$message({
-                    showClose: true,
-                    message: '加载完成',
-                    type: 'success'
-                });
-            }, 3000);
-        },
-        downloadSnap(path) {
-            let index = '';
-            let tmpPath = '';
-            if (path === 'se') {
-                if (!this.isSeRender) {
-                    tmpPath = this.rootPath + "/original"
-                } else {
-                    tmpPath = this.rootPath
-                }
-                index = this.seIndex;
-            } else if (path === 'seSide') {
-                if (!this.isSideRender) {
-                    tmpPath = this.rootPath + "/original"
-                } else {
-                    tmpPath = this.rootPath
-                }
-                index = this.sideIndex;
-            } else if (path === 'seFont') {
-                if (!this.isFontRender) {
-                    tmpPath = this.rootPath + "/original"
-                } else {
-                    tmpPath = this.rootPath
-                }
-                index = this.fontIndex;
-            }
-            let fileName = "image_" + index + ".png";
-            let bucketFileName = tmpPath + "/" + path + "/" + fileName;
-            let originalFileName = new Date().getTime() + ".png";
-            downloadPic(bucketFileName, originalFileName).then(res => {
-                this.resolveBlob(res, originalFileName)
-            })
-        },
-
-        resolveBlob(res, fileName) {
-            const aLink = document.createElement('a')
-            let blob = new Blob([res.data])
-            if (window.navigator.msSaveOrOpenBlob) {
-                navigator.msSaveBlob(blob, fileName);
-            } else {
-                aLink.href = URL.createObjectURL(blob)
-                aLink.setAttribute('download', fileName) // 设置下载文件名称
-                aLink.click()
-                window.URL.revokeObjectURL(aLink.href);
-            }
-        },
-
-        dialogOpen(val) {
-            console.log("打开")
-            this.rootPath = val.imgPath;
-            this.getFile(val.imgPath);
-        },
-        open() {
-            this.$nextTick(() => {
-                console.log(this.$refs.threeTarget)
-                this.ThreeEngine = new ThreeEngine(this.$refs.threeTarget)
-                this.ThreeEngine.addObject(...allLights)  // 添加光线
-                this.ThreeEngine.addObject(...allBaseObject)  // 添加基础模型
-            })
-        },
-        dialogClose() {
-            console.log("关闭")
-            this.semgentUrls = []
-            this.fontUrls = []
-            this.sideUrls = []
-        },
-        handleClick(tab, event) {
-            console.log(tab, event);
-        },
-        handleClose(done) {
-            // this.$confirm('是否关闭页面？', '提示', {
-            //     confirmButtonText: '确定',
-            //     cancelButtonText: '取消'
-            // }).then(() => {
-                done();
-            // }).catch(() => { });
-        },
-        getFile(rootPath) {
-            getPicUrl(rootPath).then(res => {
-                this.semgentUrls = res.data.data.seList;
-                this.fontUrls = res.data.data.seFontList;
-                this.sideUrls = res.data.data.seSideList;
-                this.semgentLen = res.data.data.seList.length - 1;
-                this.fontLen = res.data.data.seFontList.length - 1;
-                this.sideLen = res.data.data.seSideList.length - 1;
-            })
-            this.openFullScreen();
-        },
-        handleMouseWheel1(e) {
-            e.preventDefault()
-            clearTimeout(this.timer)
-            this.timer = setTimeout(() => {
-                if (!window.scrollY) {
-                    // 禁止页面滚动
-                    if (e.wheelDelta) {
-                        // 判断浏览器IE，谷歌滑轮事件
-                        var fontX = document.getElementById('fontX');
-                        var sideX = document.getElementById('sideX');
-                        if (e.wheelDelta > 0) {
-                            if (this.seIndex > 0) {
-                                this.seIndex--;
-                                fontX.setAttribute("style", "bottom: " + this.seIndex + "px !important");
-                                sideX.setAttribute("style", "bottom: " + this.seIndex + "px !important");
-                            }
-                        }
-                        if (e.wheelDelta < 0) {
-                            // 当滑轮向下滚动时
-                            if (this.seIndex < this.semgentUrls.length - 1) {
-                                this.seIndex++;
-                                fontX.setAttribute("style", "bottom: " + this.seIndex + "px !important");
-                                sideX.setAttribute("style", "bottom: " + this.seIndex + "px !important");
-                            }
-                        }
-                    }
-                }
-            }, 1)
-        },
-        handleMouseWheel2(e) {
-            e.preventDefault()
-            clearTimeout(this.timer)
-            this.timer = setTimeout(() => {
-                if (!window.scrollY) {
-                    // 禁止页面滚动
-                    if (e.wheelDelta) {
-                        // 判断浏览器IE，谷歌滑轮事件
-                        var seX = document.getElementById('seX');
-                        var sideY = document.getElementById('sideY');
-                        if (e.wheelDelta > 0) {
-                            if (this.fontIndex > 0) {
-                                this.fontIndex--;
-                                seX.setAttribute("style", "top: " + this.fontIndex + "px !important");
-                                sideY.setAttribute("style", "left: " + this.fontIndex + "px !important");
-                            }
-                        }
-                        if (e.wheelDelta < 0) {
-                            // 当滑轮向下滚动时
-                            if (this.fontIndex < this.fontUrls.length - 1) {
-                                this.fontIndex++;
-                                seX.setAttribute("style", "top: " + this.fontIndex + "px !important");
-                                sideY.setAttribute("style", "left: " + this.fontIndex + "px !important");
-                            }
-                        }
-                    }
-                }
-            }, 1)
-        },
-        handleMouseWheel3(e) {
-            e.preventDefault()
-            clearTimeout(this.timer)
-            var seY = document.getElementById('seY');
-            var fontY = document.getElementById('fontY');
-            this.timer = setTimeout(() => {
-                if (!window.scrollY) {
-                    // 禁止页面滚动
-                    if (e.wheelDelta) {
-                        // 判断浏览器IE，谷歌滑轮事件
-                        if (e.wheelDelta > 0) {
-                            if (this.sideIndex > 0) {
-                                this.sideIndex--;
-                                seY.setAttribute("style", "left: " + this.sideIndex + "px !important");
-                                fontY.setAttribute("style", "left: " + this.sideIndex + "px !important");
-                            }
-                        }
-                        if (e.wheelDelta < 0) {
-                            // 当滑轮向下滚动时
-                            if (this.sideIndex < this.sideUrls.length - 1) {
-                                this.sideIndex++;
-                                seY.setAttribute("style", "left: " + this.sideIndex + "px !important");
-                                fontY.setAttribute("style", "left: " + this.sideIndex + "px !important");
-                            }
-                        }
-                    }
-                }
-            }, 1)
-        },
-        sliderchange1() {
-            var fontX = document.getElementById('fontX');
-            var sideX = document.getElementById('sideX');
-            fontX.setAttribute("style", "bottom: " + (this.seIndex + 75) + "px !important");
-            sideX.setAttribute("style", "bottom: " + (this.seIndex + 75) + "px !important");
-        },
-        sliderchange2() {
-            var seX = document.getElementById('seX');
-            var sideY = document.getElementById('sideY');
-            seX.setAttribute("style", "top: " + (this.fontIndex + 20) + "px !important");
-            sideY.setAttribute("style", "left: " + (this.fontIndex + 20) + "px !important");
-        },
-        sliderchange3() {
-            var seY = document.getElementById('seY');
-            var fontY = document.getElementById('fontY');
-            seY.setAttribute("style", "left: " + (this.sideIndex + 20) + "px !important");
-            fontY.setAttribute("style", "left: " + (this.sideIndex + 20) + "px !important");
-        }
+  name: 'TumorView',
+  components: { SliceViewport },
+  data() {
+    return {
+      dialogVisible: false,
+      studyLoading: false,
+      patient: {},
+      rootPath: '',
+      seIndex: 0,
+      fontIndex: 0,
+      sideIndex: 0,
+      semgentUrls: [],
+      fontUrls: [],
+      sideUrls: [],
+      isSeRender: true,
+      isSideRender: true,
+      isFontRender: true,
+      threeEngine: null,
+      requestVersion: 0,
+      syncingIndices: false
     }
-};
+  },
+  computed: {
+    totalSlices() { return this.semgentUrls.length + this.fontUrls.length + this.sideUrls.length }
+  },
+  watch: {
+    seIndex(value, oldValue) { if (this.dialogVisible && !this.syncingIndices && Number.isFinite(oldValue)) setYPosition(oldValue - value) },
+    fontIndex(value, oldValue) { if (this.dialogVisible && !this.syncingIndices && Number.isFinite(oldValue)) setXPosition(oldValue - value) },
+    sideIndex(value, oldValue) { if (this.dialogVisible && !this.syncingIndices && Number.isFinite(oldValue)) setZPosition(oldValue - value) }
+  },
+  beforeDestroy() { this.releaseViewer() },
+  methods: {
+    async dialogOpen(patient) {
+      this.patient = patient || {}
+      this.rootPath = patient.imgPath
+      this.dialogVisible = true
+      this.studyLoading = true
+      this.syncingIndices = true
+      this.resetStudy()
+      const version = ++this.requestVersion
+      try {
+        const res = await getPicUrl(this.rootPath)
+        if (version !== this.requestVersion) return
+        const data = res.data.data || {}
+        this.semgentUrls = data.seList || []
+        this.fontUrls = data.seFontList || []
+        this.sideUrls = data.seSideList || []
+        this.seIndex = this.middleIndex(this.semgentUrls)
+        this.fontIndex = this.middleIndex(this.fontUrls)
+        this.sideIndex = this.middleIndex(this.sideUrls)
+      } catch (error) {
+        this.$message.error('影像序列读取失败，请稍后重试')
+      } finally {
+        if (version === this.requestVersion) {
+          this.studyLoading = false
+          this.$nextTick(() => { this.syncingIndices = false })
+        }
+      }
+    },
+    middleIndex(list) { return list.length ? Math.floor((list.length - 1) / 2) : 0 },
+    slicePercent(index, list) { return list.length > 1 ? Math.round(index / (list.length - 1) * 100) : 50 },
+    resetStudy() {
+      this.semgentUrls = []
+      this.fontUrls = []
+      this.sideUrls = []
+      this.seIndex = this.fontIndex = this.sideIndex = 0
+      this.isSeRender = this.isSideRender = this.isFontRender = true
+      resetPositions()
+    },
+    initThreeScene() {
+      this.disposeThreeScene()
+      this.$nextTick(() => {
+        if (!this.$refs.threeTarget) return
+        this.threeEngine = new ThreeEngine(this.$refs.threeTarget)
+        this.threeEngine.addObject(...allLights)
+        this.threeEngine.addObject(...allBaseObject)
+      })
+    },
+    async toggleSeries(key) {
+      const config = {
+        se: { flag: 'isSeRender', list: 'semgentUrls', index: 'seIndex' },
+        seSide: { flag: 'isSideRender', list: 'sideUrls', index: 'sideIndex' },
+        seFont: { flag: 'isFontRender', list: 'fontUrls', index: 'fontIndex' }
+      }[key]
+      if (!config) return
+      const nextSegmented = !this[config.flag]
+      const path = nextSegmented ? this.rootPath : this.rootPath + '/original'
+      this.studyLoading = true
+      try {
+        const res = await changePicUrl(path, key)
+        this[config.list] = res.data.data || []
+        this[config.index] = Math.min(this[config.index], Math.max(this[config.list].length - 1, 0))
+        this[config.flag] = nextSegmented
+      } catch (error) {
+        this.$message.error('切片模式切换失败')
+      } finally {
+        this.studyLoading = false
+      }
+    },
+    downloadCurrent(key) {
+      const config = {
+        se: { rendered: this.isSeRender, index: this.seIndex },
+        seSide: { rendered: this.isSideRender, index: this.sideIndex },
+        seFont: { rendered: this.isFontRender, index: this.fontIndex }
+      }[key]
+      if (!config) return
+      const path = config.rendered ? this.rootPath : this.rootPath + '/original'
+      const fileName = 'image_' + config.index + '.png'
+      downloadPic(path + '/' + key + '/' + fileName, fileName).then(res => this.resolveBlob(res, fileName))
+    },
+    resolveBlob(res, fileName) {
+      const url = URL.createObjectURL(new Blob([res.data]))
+      const link = document.createElement('a')
+      link.href = url
+      link.download = fileName
+      link.click()
+      URL.revokeObjectURL(url)
+    },
+    disposeThreeScene() {
+      if (this.threeEngine) this.threeEngine.dispose()
+      this.threeEngine = null
+    },
+    releaseViewer() {
+      this.requestVersion++
+      this.disposeThreeScene()
+      this.resetStudy()
+      this.studyLoading = false
+      this.syncingIndices = false
+    }
+  }
+}
 </script>
-<style>
-.out1 {
-    width: 45vh;
-    height: 45vh;
-    /* border: 2px solid red; */
-    position: absolute;
-    z-index: 100;
-}
-
-.out2 {
-    width: 45vh;
-    height: 45vh;
-    margin-left: 50vh;
-    /* border: 2px solid blue; */
-    position: absolute;
-    z-index: 100;
-}
-
-.out3 {
-    width: 45vh;
-    height: 45vh;
-    margin-top: 50vh;
-    margin-left: 50vh;
-    /* border: 2px solid gold; */
-    position: absolute;
-    z-index: 100;
-}
-
-.out4 {
-    width: 45vh;
-    height: 45vh;
-    margin-top: 50vh;
-    /* margin-left: 50vh; */
-    /* border: 2px solid gold; */
-    position: absolute;
-    z-index: 100;
-}
-
-.div1 {
-    width: 40vh;
-    height: 40vh;
-    position: absolute;
-    z-index: 100;
-    /* border: 2px solid red; */
-}
-
-.div2 {
-    width: 40vh;
-    height: 40vh;
-    position: absolute;
-    z-index: 100;
-    /* border: 2px solid blue; */
-}
-
-.div3 {
-    width: 40vh;
-    height: 40vh;
-    position: absolute;
-    z-index: 100;
-    /* border: 2px solid gold; */
-}
-
-.div4 {
-    width: 40vh;
-    height: 40vh;
-    position: absolute;
-    z-index: 100;
-    /* border: 2px solid gold; */
-    background-color: black;
-}
-
-.image1 {
-    width: 40vh;
-    height: 40vh;
-}
-
-.image2 {
-    width: 40vh;
-    height: 40vh;
-}
-
-.image3 {
-    width: 40vh;
-    height: 40vh;
-}
-
-.text {
-    position: absolute;
-    width: 65px;
-    top: 41vh;
-    left: 35vh;
-    font-size: smaller;
-}
-
-.el-slider.is-vertical .el-slider__runway {
-    width: 15px !important;
-}
-
-.el-slider.is-vertical .el-slider__bar {
-    width: 15px !important;
-}
-
-.postitonText {
-    color: gold;
-    position: absolute;
-    z-index: 9999;
-    font-family: 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif;
-    font-size: medium;
-}
-
-.coordinateX {
-    width: 40vh;
-    height: 0px;
-    position: absolute;
-    z-index: 9999;
-    /* margin-top: 20vh; */
-    border: 2px dashed rgb(68, 63, 221);
-}
-
-.coordinateY {
-    width: 0px;
-    height: 40vh;
-    position: absolute;
-    z-index: 9999;
-    /* margin-left: 20vh; */
-    border: 2px dashed rgb(68, 63, 221);
-}
-
-.el-loading-mask {
-    position: absolute !important;
-    z-index: 10000 !important;
-    background-color: rgba(255, 255, 255, .9);
-    margin: 0;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    transition: opacity .3s
-}
-</style>
 
 <style lang="scss">
-.sliderMain {
-    .el-slider {
-        width: 190px;
-        height: 6px;
-        position: relative;
-        top: -14px;
-        left: 2px;
-    }
-
-    .el-slider__runway {
-        background: #dedede;
-        border-radius: 0;
-    }
-
-
-    .el-slider__bar {
-        background: #dedede;
-        border-radius: 0;
-    }
-
-
-    .el-slider__button {
-        width: 15px;
-        height: 20px;
-        background: #ffffff;
-        border: none;
-        border-radius: 0;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, .12), 0 0 6px rgba(0, 0, 0, .04);
-        margin-left: 10px;
-    }
-
-    .el-slider__button-wrapper::after {
-        width: 0%;
-    }
-
-}
+.medical-viewer-dialog { height:96vh; margin-bottom:0 !important; display:flex; flex-direction:column; overflow:hidden; background:#07131b; border:1px solid #29404c; border-radius:10px; box-shadow:0 24px 70px rgba(0,0,0,.45); }
+.medical-viewer-dialog .el-dialog__header { height:64px; flex:0 0 64px; padding:0 60px 0 18px; display:flex; align-items:center; background:#10232e; border-bottom:1px solid #29404c; box-sizing:border-box; }.medical-viewer-dialog .el-dialog__headerbtn { top:22px; }.medical-viewer-dialog .el-dialog__headerbtn .el-dialog__close { color:#8ca3af; }.medical-viewer-dialog .el-dialog__body { min-height:0; flex:1; display:flex; flex-direction:column; padding:0; color:#c9d8df; }
+.viewer-titlebar { width:100%; display:flex; align-items:center; justify-content:space-between; }.viewer-brand { display:flex; align-items:center; gap:10px; }.viewer-logo { width:32px; height:32px; display:grid; place-items:center; border-radius:8px; color:#07131b; background:#43c9c0; font-weight:800; }.viewer-brand strong,.viewer-brand small { display:block; }.viewer-brand strong { color:#eff7f9; font-size:14px; }.viewer-brand small { margin-top:3px; color:#6f8996; font-size:9px; letter-spacing:.5px; }.patient-summary { display:flex; align-items:center; gap:28px; margin-right:24px; }.patient-summary span { color:#c0d0d7; font-size:11px; }.patient-summary small { display:block; margin-bottom:3px; color:#617b88; font-size:8px; }
+.viewer-toolbar { height:46px; flex:0 0 46px; display:flex; align-items:center; justify-content:space-between; padding:0 14px; background:#0b1922; border-bottom:1px solid #233743; }.tool-group { display:flex; gap:5px; }.tool-group button { height:30px; display:flex; align-items:center; gap:6px; padding:0 10px; border:1px solid transparent; border-radius:5px; color:#7f99a6; background:transparent; font-size:10px; cursor:pointer; }.tool-group button:hover { color:#d9e7ec; border-color:#2b4654; background:#142630; }.viewer-legend { display:flex; align-items:center; gap:7px; color:#6f8996; font-size:9px; }.legend-segment { width:12px; height:5px; margin-left:13px; background:#db4c72; }.legend-crosshair { width:12px; border-top:1px dashed #35a9df; }
+.viewer-grid { min-height:0; flex:1; display:grid; grid-template-columns:1fr 1fr; grid-template-rows:1fr 1fr; gap:6px; padding:6px; background:#040a0e; }.volume-viewport { min-width:0; min-height:0; display:flex; flex-direction:column; overflow:hidden; background:#071018; border:1px solid #203441; border-radius:8px; }.volume-viewport header { height:42px; flex:0 0 42px; display:flex; align-items:center; justify-content:space-between; padding:0 12px; color:#d8e5eb; background:#101f29; border-bottom:1px solid #203441; }.volume-viewport header div { display:flex; align-items:center; gap:8px; }.volume-viewport header span { width:6px; height:6px; border-radius:50%; background:#e6bb4f; }.volume-viewport header strong { font-size:12px; }.volume-viewport header small { color:#698391; font-size:10px; }.volume-viewport header em { color:#526b77; font-size:9px; font-style:normal; }.three-stage { min-height:0; flex:1; overflow:hidden; background:radial-gradient(circle at center, #122530, #03070a 70%); }.three-stage canvas { display:block; }.volume-viewport footer { height:38px; flex:0 0 38px; display:flex; align-items:center; gap:16px; padding:0 12px; color:#607b88; background:#101f29; border-top:1px solid #203441; font-size:9px; }.volume-viewport footer i { display:inline-block; width:8px; margin-right:5px; border-top:2px solid #dd4e70; }.volume-viewport footer span:nth-child(2) i { border-color:#4bc88a; }.volume-viewport footer span:nth-child(3) i { border-color:#4b9fe0; }
+.viewer-statusbar { height:28px; flex:0 0 28px; display:flex; align-items:center; justify-content:space-between; padding:0 14px; color:#55707d; background:#0a171f; border-top:1px solid #203441; font-size:9px; }.status-online { display:inline-block; width:6px; height:6px; margin-right:6px; border-radius:50%; background:#38c698; }
+@media (max-width: 1000px) { .patient-summary span:nth-child(3) { display:none; }.medical-viewer-dialog { width:98% !important; }.viewer-grid { grid-template-columns:1fr; grid-template-rows:repeat(4, 340px); overflow-y:auto; }.viewer-grid > * { min-height:340px; } }
 </style>

--- a/designSystem/BrainU-frontend/src/views/workSpace/workSpace.vue
+++ b/designSystem/BrainU-frontend/src/views/workSpace/workSpace.vue
@@ -117,7 +117,7 @@
 import { listPatientIsHeadle, savePatient, deletePatient } from "@/api/patient"
 import { listDoctor } from "@/api/doctor";
 import { downloadTumorFile } from "@/api/segment"
-import TumorView from "./components/tumorView"
+const TumorView = () => import(/* webpackChunkName: "medical-viewer" */ './components/tumorView')
 export default {
     name: '',
     components: {


### PR DESCRIPTION
## 改动概览

### 前端性能与界面

- 将三个方向的切片从 `v-for + v-show` 全量挂载改为单图片节点按需渲染
- 仅预取当前切片前后各 2 帧，并限制解码缓存大小
- 保留三视图定位线联动、滚轮浏览、原图/分割图切换及下载能力
- 为 Three.js 引擎增加动画取消、事件解绑、Controls/WebGL 释放和尺寸监听
- 医学影像查看器改为独立异步 chunk，所有业务页面改为路由懒加载
- Element UI 改为按需注册，移除未使用的 vtk.js / kw-web-suite 依赖
- 重做主框架与四视图界面，统一为医学影像工作站视觉

### 搭建与部署文档

- 完整保留原 README 的项目介绍、模型数据、实验结果、架构图、项目亮点和界面截图
- 将原来的“系统部署：待完善”替换为详细搭建与部署流程
- 提供 MySQL 最小表结构、初始化医生和模型 SQL
- 补充 Redis、MinIO、Python、Spring Boot、Vue 本地搭建步骤
- 补充生产构建、systemd、Nginx、HTTPS、端口和备份方案
- 补充微服务版本现状、发布回滚、上线验收和常见问题
- 明确列出历史凭据、MinIO 桶名、上传路径、CUDA 和同机部署等必改项

## 性能收益

- 切片图片 DOM：每个序列由数百个节点降为 1 个，三个方向合计固定为 3 个
- 首次图片请求：由全量切片降为当前帧和邻近帧
- 首屏 vendor 包：约 1.14 MiB → 799 KiB，减少约 31%
- Three.js 查看器约 510 KiB，改为进入工作区并打开预览时才加载
- 关闭查看器后不再保留 requestAnimationFrame 和 WebGL 上下文

## 验证

- `npm run lint`：通过
- `npm run build`：通过
- `git diff --check -- README.md`：通过
- 原 README 部署章节前的内容与作者、反馈章节对比确认保留
- 新部署文档未写入仓库历史配置中的实际地址或凭据

构建仍提示旧版 Vue CLI/Sass API 以及现存大资源警告，未影响本次构建产物。