### PR TITLE
将 Java-Python 原生 Socket 通信改为 HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,23 +173,23 @@ brainu:
 
 并使用 `Paths.get(uploadDir, fileId, originalFilename)` 创建父目录。Java 与 Python 必须能够访问同一份上传文件。
 
-### 5. Python 与 Java 当前要求同机运行
+### 5. Python HTTP 服务与 Java 默认同机运行
 
-Java 后端将推理服务地址写死为：
+Python 现在通过 HTTP 提供 `POST /segment`，Java 默认调用：
 
 ```text
-127.0.0.1:50007
+http://127.0.0.1:50007
 ```
 
-因此当前最稳妥的部署方式是让 Java 和 Python 运行在同一台服务器，并共享本地文件系统。如果拆成两个 Docker 容器或两台服务器，需要同时完成：
+地址可通过 `brainu.ai.base-url` 或环境变量 `BRAINU_AI_BASE_URL` 修改。由于 Java 传给 Python 的仍是本地 MRI 目录路径，当前最稳妥的部署方式仍是让 Java 和 Python 运行在同一台服务器，并共享本地文件系统。如果拆成两个 Docker 容器或两台服务器，需要同时完成：
 
-- 将 Python host、port 改为配置项。
 - 使用共享卷或对象存储传递原始 MRI 文件。
-- 为 TCP 调用增加超时、失败重试和任务状态。
+- 只在可信内网暴露 Python HTTP 端口。
+- 根据推理耗时设置 HTTP 读取超时、失败重试和任务状态。
 
 ### 6. 当前 Python 推理流程默认需要 CUDA
 
-`python_server/server.py` 会设置 CUDA 设备。没有 NVIDIA GPU 或 CUDA 环境时，需要先将 `torch.cuda.set_device(...)` 放入 `torch.cuda.is_available()` 判断中，并使用 CPU 版本 PyTorch。CPU 可以运行，但完整体数据推理会明显变慢。
+`python_server/server.py` 会在 CUDA 可用时设置 GPU，否则自动回退到 CPU。CPU 可以运行，但完整体数据推理会明显变慢；模型权重也必须兼容当前设备和网络结构。
 
 ### 7. 输入数据不是任意 MRI 文件
 
@@ -412,6 +412,13 @@ minio:
   endpoint: http://127.0.0.1:9000
   user-name: brainu-admin
   password: replace-with-a-strong-password
+
+brainu:
+  ai:
+    base-url: http://127.0.0.1:50007
+    connect-timeout: 5000
+    read-timeout: 1800000
+    connection-request-timeout: 5000
 ```
 
 创建最小权限数据库用户：
@@ -441,10 +448,10 @@ PyTorch 应按显卡和 CUDA 版本从官方渠道安装。安装其他依赖：
 
 ```bash
 python -m pip install --upgrade pip
-pip install numpy SimpleITK imageio Pillow opencv-python-headless minio matplotlib scipy
+pip install -r requirements.txt
 ```
 
-还需要安装 `torch`。例如 CPU 调试环境可安装 CPU 版本；GPU 环境必须选择与 CUDA 对应的版本。项目没有提交经过锁定验证的 `requirements.txt`，首次部署后应执行：
+`requirements.txt` 包含 `torch`，但 GPU 环境通常应先按 CUDA 版本安装 PyTorch，再安装其余依赖。首次验证后建议锁定实际版本：
 
 ```bash
 pip freeze > requirements.lock.txt
@@ -469,15 +476,13 @@ source .venv/bin/activate
 python server.py
 ```
 
-确认端口：
+验证 HTTP 健康检查：
 
 ```bash
-# Linux
-ss -lntp | grep 50007
-
-# Windows PowerShell
-Get-NetTCPConnection -LocalPort 50007
+curl http://127.0.0.1:50007/health
 ```
+
+预期返回 `status: ok`，并显示当前使用 `cuda` 或 `cpu`。Python 接口还提供 `POST /segment`，该接口只应由 Java 后端在内网调用。
 
 ### 8. 启动 Spring Boot 后端
 
@@ -551,7 +556,7 @@ Redis
   ↓
 MinIO
   ↓
-Python 推理服务 :50007
+Python HTTP 推理服务 :50007
   ↓
 Spring Boot :8000/api
   ↓
@@ -610,6 +615,10 @@ SPRING_REDIS_DATABASE=10
 MINIO_ENDPOINT=https://minio.example.com
 MINIO_USER_NAME=brainu-app
 MINIO_PASSWORD=replace-me
+BRAINU_AI_BASE_URL=http://127.0.0.1:50007
+BRAINU_AI_CONNECT_TIMEOUT=5000
+BRAINU_AI_READ_TIMEOUT=1800000
+BRAINU_AI_CONNECTION_REQUEST_TIMEOUT=5000
 SERVER_PORT=8000
 SERVER_SERVLET_CONTEXT_PATH=/api
 ```
@@ -686,7 +695,7 @@ WorkingDirectory=/opt/brainu/current/python_server
 EnvironmentFile=-/etc/brainu/python.env
 Environment=PYTHONUNBUFFERED=1
 Environment=CUDA_VISIBLE_DEVICES=0
-ExecStart=/opt/brainu/venv/bin/python /opt/brainu/current/python_server/server.py
+ExecStart=/opt/brainu/venv/bin/gunicorn --bind 127.0.0.1:50007 --workers 1 --threads 4 --timeout 1800 server:app
 Restart=on-failure
 RestartSec=5
 TimeoutStopSec=30
@@ -801,7 +810,7 @@ sudo systemctl reload nginx
 | --- | --- | --- |
 | 80/443 | Nginx | 是 |
 | 8000 | Spring Boot | 否，仅本机或内网 |
-| 50007 | Python TCP | 否，仅本机 |
+| 50007 | Python HTTP 推理接口 | 否，仅本机或可信内网 |
 | 3306 | MySQL | 否 |
 | 6379 | Redis | 否 |
 | 9000 | MinIO API | 通过 HTTPS 反代或受控网络 |
@@ -865,7 +874,7 @@ mc mirror --overwrite production/brainu /backup/brainu-minio
 2. 多个 `application.yml` 和 `bootstrap.properties` 写死了远程地址及凭据。
 3. 各服务需统一数据库、Redis、MinIO 和 Nacos 配置来源。
 4. Gateway 端口为 88，前端生产 `/api` 路由需要相应调整。
-5. Python Socket 和本地文件共享问题仍然存在。
+5. Python HTTP 服务与 Java 之间仍然需要共享 MRI 文件路径。
 
 完成改造后的启动顺序应为：
 
@@ -930,7 +939,7 @@ sudo systemctl reload nginx
 - 检查 Java 进程对上传目录的写权限。
 - 检查 Nginx 与 Spring 的 1 GB 上传限制。
 
-### 点击分割后连接被拒绝
+### 点击分割后 Python 接口连接失败
 
 ```text
 Connection refused: 127.0.0.1:50007
@@ -938,7 +947,8 @@ Connection refused: 127.0.0.1:50007
 
 - Python 服务未启动。
 - Python 启动时因 CUDA、模型或依赖错误退出。
-- Java 与 Python 不在同一网络命名空间。
+- `brainu.ai.base-url` 配置错误，或 Java 与 Python 不在同一网络命名空间。
+- 可先执行 `curl http://127.0.0.1:50007/health` 验证服务。
 
 ### Python 找不到模型
 

--- a/designSystem/BrainU-backend/pom.xml
+++ b/designSystem/BrainU-backend/pom.xml
@@ -117,6 +117,11 @@
             <version>${httpcore.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
+        </dependency>
+        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <version>${commons-lang.version}</version>

--- a/designSystem/BrainU-backend/src/main/java/com/peiyp/brainu/config/BrainUAiConfig.java
+++ b/designSystem/BrainU-backend/src/main/java/com/peiyp/brainu/config/BrainUAiConfig.java
@@ -1,0 +1,54 @@
+package com.peiyp.brainu.config;
+
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Pooled HTTP client used only for calls to the Python inference process.
+ */
+@Configuration
+@EnableConfigurationProperties(BrainUAiProperties.class)
+public class BrainUAiConfig {
+
+    @Bean(destroyMethod = "close")
+    public PoolingHttpClientConnectionManager brainuAiConnectionManager() {
+        PoolingHttpClientConnectionManager manager = new PoolingHttpClientConnectionManager();
+        manager.setMaxTotal(10);
+        manager.setDefaultMaxPerRoute(5);
+        return manager;
+    }
+
+    @Bean(destroyMethod = "close")
+    public CloseableHttpClient brainuAiHttpClient(
+            BrainUAiProperties properties,
+            @Qualifier("brainuAiConnectionManager") PoolingHttpClientConnectionManager connectionManager) {
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(properties.getConnectTimeout())
+                .setSocketTimeout(properties.getReadTimeout())
+                .setConnectionRequestTimeout(properties.getConnectionRequestTimeout())
+                .build();
+
+        return HttpClients.custom()
+                .setConnectionManager(connectionManager)
+                .setDefaultRequestConfig(requestConfig)
+                .evictExpiredConnections()
+                .evictIdleConnections(60, TimeUnit.SECONDS)
+                .build();
+    }
+
+    @Bean("brainuAiRestTemplate")
+    public RestTemplate brainuAiRestTemplate(
+            @Qualifier("brainuAiHttpClient") CloseableHttpClient httpClient) {
+        return new RestTemplate(new HttpComponentsClientHttpRequestFactory(httpClient));
+    }
+}

--- a/designSystem/BrainU-backend/src/main/java/com/peiyp/brainu/config/BrainUAiProperties.java
+++ b/designSystem/BrainU-backend/src/main/java/com/peiyp/brainu/config/BrainUAiProperties.java
@@ -1,0 +1,32 @@
+package com.peiyp.brainu.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Python inference service connection settings.
+ */
+@Data
+@ConfigurationProperties(prefix = "brainu.ai")
+public class BrainUAiProperties {
+
+    /**
+     * Internal HTTP address of the Python inference service.
+     */
+    private String baseUrl = "http://127.0.0.1:50007";
+
+    /**
+     * Timeout for establishing a connection, in milliseconds.
+     */
+    private int connectTimeout = 5000;
+
+    /**
+     * Timeout while waiting for a segmentation result, in milliseconds.
+     */
+    private int readTimeout = 1800000;
+
+    /**
+     * Timeout for obtaining a connection from the HTTP pool, in milliseconds.
+     */
+    private int connectionRequestTimeout = 5000;
+}

--- a/designSystem/BrainU-backend/src/main/java/com/peiyp/brainu/integration/ai/AiInferenceClient.java
+++ b/designSystem/BrainU-backend/src/main/java/com/peiyp/brainu/integration/ai/AiInferenceClient.java
@@ -1,0 +1,56 @@
+package com.peiyp.brainu.integration.ai;
+
+import com.peiyp.brainu.config.BrainUAiProperties;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * HTTP client for the Python inference service.
+ */
+@Component
+public class AiInferenceClient {
+
+    private final RestTemplate restTemplate;
+    private final BrainUAiProperties properties;
+
+    public AiInferenceClient(
+            @Qualifier("brainuAiRestTemplate") RestTemplate restTemplate,
+            BrainUAiProperties properties) {
+        this.restTemplate = restTemplate;
+        this.properties = properties;
+    }
+
+    public String segment(String modelPath, String filePath, String modelName) {
+        String endpoint = trimTrailingSlash(properties.getBaseUrl()) + "/segment";
+        AiSegmentRequest payload = new AiSegmentRequest(modelPath, filePath, modelName);
+
+        try {
+            ResponseEntity<AiSegmentResponse> response = restTemplate.postForEntity(
+                    endpoint, payload, AiSegmentResponse.class);
+            AiSegmentResponse body = response.getBody();
+            if (body == null || !StringUtils.hasText(body.getImagePath())) {
+                throw new IllegalStateException("Python inference service returned an empty imagePath");
+            }
+            return body.getImagePath();
+        } catch (HttpStatusCodeException e) {
+            throw new IllegalStateException(
+                    "Python inference service returned HTTP " + e.getRawStatusCode()
+                            + ": " + e.getResponseBodyAsString(), e);
+        } catch (RestClientException e) {
+            throw new IllegalStateException(
+                    "Unable to call Python inference service at " + endpoint, e);
+        }
+    }
+
+    private String trimTrailingSlash(String value) {
+        if (!StringUtils.hasText(value)) {
+            throw new IllegalStateException("brainu.ai.base-url must not be empty");
+        }
+        return value.replaceAll("/+$", "");
+    }
+}

--- a/designSystem/BrainU-backend/src/main/java/com/peiyp/brainu/integration/ai/AiSegmentRequest.java
+++ b/designSystem/BrainU-backend/src/main/java/com/peiyp/brainu/integration/ai/AiSegmentRequest.java
@@ -1,0 +1,12 @@
+package com.peiyp.brainu.integration.ai;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AiSegmentRequest {
+    private String modelPath;
+    private String filePath;
+    private String modelName;
+}

--- a/designSystem/BrainU-backend/src/main/java/com/peiyp/brainu/integration/ai/AiSegmentResponse.java
+++ b/designSystem/BrainU-backend/src/main/java/com/peiyp/brainu/integration/ai/AiSegmentResponse.java
@@ -1,0 +1,9 @@
+package com.peiyp.brainu.integration.ai;
+
+import lombok.Data;
+
+@Data
+public class AiSegmentResponse {
+    private String imagePath;
+    private String message;
+}

--- a/designSystem/BrainU-backend/src/main/java/com/peiyp/brainu/service/impl/SegmentServiceImpl.java
+++ b/designSystem/BrainU-backend/src/main/java/com/peiyp/brainu/service/impl/SegmentServiceImpl.java
@@ -8,6 +8,7 @@ import com.peiyp.brainu.entity.ModelInfo;
 import com.peiyp.brainu.entity.NotifyInfo;
 import com.peiyp.brainu.entity.PatientInfo;
 import com.peiyp.brainu.mapper.BrainFileMapper;
+import com.peiyp.brainu.integration.ai.AiInferenceClient;
 import com.peiyp.brainu.res.Constants;
 import com.peiyp.brainu.service.IModelInfoService;
 import com.peiyp.brainu.service.INotifyInfoService;
@@ -22,8 +23,6 @@ import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.*;
-import java.net.Socket;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -45,6 +44,8 @@ public class SegmentServiceImpl implements SegmentService {
     private IModelInfoService modelInfoService;
     @Resource
     private INotifyInfoService notifyInfoService;
+    @Resource
+    private AiInferenceClient aiInferenceClient;
 
     public static String path = "";
 
@@ -106,24 +107,21 @@ public class SegmentServiceImpl implements SegmentService {
         String modelPath = data.getModelPath();
         String modelName = data.getModelName();
         try {
-            String message = "1" + modelPath + "|" + uploadPath + "|" + modelName + "end send";
-            String serverMsg = this.getSocketServerMsg("127.0.0.1", 50007, message);
-            String[] split = serverMsg.split("\\|");
-            System.out.println(serverMsg);
-            path = split[0];
-            if (!"".equals(serverMsg)) {
+            String imagePath = aiInferenceClient.segment(modelPath, uploadPath, modelName);
+            path = imagePath;
+            if (imagePath != null && !imagePath.trim().isEmpty()) {
                 PatientInfo patientInfo = patientInfoService.getById(Long.parseLong(patientId));
                 patientInfo.setIsHandle(1);
                 String doctorId = (String) request.getAttribute("doctorId");
                 patientInfo.setHandleBy(doctorId);
-                patientInfo.setImgPath(split[0]);
+                patientInfo.setImgPath(imagePath);
                 patientInfo.setUpdateTime(new Date());
                 patientInfoService.save(patientInfo);
                 NotifyInfo notifyInfo = notifyInfoService.getOne(new LambdaQueryWrapper<NotifyInfo>()
                         .eq(NotifyInfo::getPatientId, patientId));
                 notifyInfo.setIsHandle(1);
                 notifyInfoService.updateById(notifyInfo);
-                return serverMsg;
+                return imagePath;
             }
             return null;
         } catch (Exception e) {
@@ -233,32 +231,5 @@ public class SegmentServiceImpl implements SegmentService {
         } catch (IOException ex) {
             ex.printStackTrace();
         }
-    }
-
-
-    private String getSocketServerMsg(String host, int port, String message) throws Exception {
-        // 与服务端建立连接
-        Socket socket = new Socket(host, port);
-        // 获得输出流
-        OutputStream outputStream = socket.getOutputStream();
-        PrintWriter pWriter = new PrintWriter(outputStream);
-        pWriter.write(message);
-        pWriter.flush();
-        // 通过shutdownOutput高速服务器已经发送完数据，后续只能接受数据
-        socket.shutdownOutput();
-        // 获得输入流
-        InputStream inputStream = socket.getInputStream();
-
-        byte[] bytes = new byte[1024];
-        int len;
-        StringBuilder sb = new StringBuilder();
-        while ((len = inputStream.read(bytes)) != -1) {
-            // 注意指定编码格式，发送方和接收方一定要统一，建议使用UTF-8
-            sb.append(new String(bytes, 0, len, StandardCharsets.UTF_8)).append("|");
-        }
-        inputStream.close();
-        outputStream.close();
-        socket.close();
-        return sb.toString();
     }
 }

--- a/python_server/requirements.txt
+++ b/python_server/requirements.txt
@@ -1,0 +1,11 @@
+Flask>=2.3,<4
+gunicorn>=21,<24
+SimpleITK
+imageio
+matplotlib
+minio
+numpy
+opencv-python-headless
+Pillow
+scipy
+torch

--- a/python_server/server.py
+++ b/python_server/server.py
@@ -3,7 +3,11 @@
 # @author: peiYP
 
 
-import socket
+import logging
+import os
+from threading import Lock
+
+from flask import Flask, jsonify, request
 from data_loader.data_loader_self import DataLoaderSelf
 
 from src.utils import *
@@ -32,7 +36,8 @@ batch_size = 32
 # multi-GPU
 cuda_available = torch.cuda.is_available()
 device_ids = [0]  # multi-GPU
-torch.cuda.set_device(device_ids[0])
+if cuda_available:
+    torch.cuda.set_device(device_ids[0])
 
 def load_model(modelPath, modelName):
     if (modelName == "U-Net模型"):
@@ -43,7 +48,8 @@ def load_model(modelPath, modelName):
         net = net.cuda()
         net = nn.DataParallel(net, device_ids=device_ids)
 
-    state_dict = torch.load(modelPath)
+    map_location = None if cuda_available else torch.device("cpu")
+    state_dict = torch.load(modelPath, map_location=map_location)
     net.load_state_dict(state_dict)
     return net
 
@@ -112,24 +118,6 @@ def evaluation(net, test_dataset, criterion, save_dir=None, model_dir=None):
 
 
 
-End = 'end send' # 这里是为了判断对应的客户端请求命令的结束标志，目的是为了接受超过1024个字符的(client)客户端请求。
-def recv_end(the_socket):
-    total_data = []
-    while True:
-        data = the_socket.recv(8192).decode('utf-8')
-        if End in data:
-            total_data.append(data[:data.find(End)])
-            break
-        total_data.append(data)
-        if len(total_data) > 1:
-            # check if end_of_data was split
-            last_pair = total_data[-2] + total_data[-1]
-            if End in last_pair:
-                total_data[-2] = last_pair[:last_pair.find(End)]
-                total_data.pop()
-                break
-    return ''.join(total_data)
-
 def segment(modelPath, filePath, modelName):
     net = load_model(modelPath, modelName)
 
@@ -148,28 +136,55 @@ def segment(modelPath, filePath, modelName):
     return img_path
 
 
+app = Flask(__name__)
+inference_lock = Lock()
+logging.basicConfig(level=os.getenv("BRAINU_AI_LOG_LEVEL", "INFO"))
+logger = logging.getLogger("brainu-ai")
 
-HOST = ''  # Symbolic name meaning all available interfaces
-PORT = 50007  # Arbitrary non-privileged port
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-s.bind((HOST, PORT))
-s.listen(1)
-while 1:
-    conn, addr = s.accept()
-    print('Connected by', addr)
-    data = recv_end(conn)
-    method = data[0]
-    subdata = data[1:]
-    if (method == "1"):  # 当客户端传递过来的第一个字符为1时，params表示传递过来的参数
-        params = subdata.split("|")
-        # 这里写要调用的函数
-        print(params[0], params[1], params[2])
-        img_path = segment(params[0], params[1], params[2])
-        # 将结果返回给客户端
-        conn.send(img_path.encode('utf-8'))
 
-    # elif method=='2': #当客户端传递过来的第一个字符为2时
-    #   #需要执行的命令2
+@app.get("/health")
+def health():
+    return jsonify({
+        "status": "ok",
+        "busy": inference_lock.locked(),
+        "device": "cuda" if cuda_available else "cpu"
+    })
 
-    # update plot
-    conn.close()
+
+@app.post("/segment")
+def segment_api():
+    payload = request.get_json(silent=True) or {}
+    model_path = payload.get("modelPath")
+    file_path = payload.get("filePath")
+    model_name = payload.get("modelName")
+
+    missing = [name for name, value in (
+        ("modelPath", model_path),
+        ("filePath", file_path),
+        ("modelName", model_name)
+    ) if not value]
+    if missing:
+        return jsonify({"message": "Missing required fields: " + ", ".join(missing)}), 400
+    if not os.path.isfile(model_path):
+        return jsonify({"message": "Model file does not exist"}), 400
+    if not os.path.isdir(file_path):
+        return jsonify({"message": "MRI input directory does not exist"}), 400
+    if not inference_lock.acquire(blocking=False):
+        return jsonify({"message": "Inference service is busy"}), 409
+
+    try:
+        logger.info("Starting segmentation with model %s", model_name)
+        image_path = segment(model_path, file_path, model_name)
+        logger.info("Segmentation completed")
+        return jsonify({"imagePath": image_path})
+    except Exception:
+        logger.exception("Segmentation failed")
+        return jsonify({"message": "Segmentation failed; check Python service logs"}), 500
+    finally:
+        inference_lock.release()
+
+
+if __name__ == "__main__":
+    host = os.getenv("BRAINU_AI_HOST", "127.0.0.1")
+    port = int(os.getenv("BRAINU_AI_PORT", "50007"))
+    app.run(host=host, port=port, threaded=True, use_reloader=False)


### PR DESCRIPTION
## 背景

原实现并不是 WebSocket，而是自定义的原生 TCP 短连接：Java 每次分割都会 `new Socket(127.0.0.1, 50007)`，发送以 `end send` 结尾的字符串，Python 推理完成后返回路径并关闭连接。

本 PR 将这套私有协议替换为标准 HTTP JSON API。

## 主要改动

### Python

- 新增 `GET /health` 健康检查，返回运行状态、繁忙状态和 CPU/CUDA 设备
- 新增 `POST /segment` 推理接口
- 校验 `modelPath`、`filePath` 和 `modelName`
- 使用进程内锁限制同一进程只运行一个推理任务，繁忙时返回 HTTP 409
- 推理异常返回标准 HTTP 500，并将详细堆栈写入 Python 日志
- 默认仅监听 `127.0.0.1:50007`
- 支持 `BRAINU_AI_HOST`、`BRAINU_AI_PORT` 和日志级别环境变量
- CUDA 不可用时自动回退到 CPU
- 新增 `requirements.txt`，生产环境支持 Gunicorn 单 worker 部署
- 删除原生 Socket、`end send` 和手动分包代码

### Java

- 新增 `AiInferenceClient`，以 JSON 调用 Python `/segment`
- 新增独立的连接池和 `RestTemplate`
- 默认连接超时 5 秒、连接池等待 5 秒、推理读取超时 30 分钟
- 服务地址通过 `brainu.ai.base-url` / `BRAINU_AI_BASE_URL` 配置
- 对 Python 非 2xx、空 `imagePath` 和连接失败提供明确异常
- `SegmentServiceImpl` 删除每请求创建/关闭 Socket 的实现

### 文档

- README 更新为 HTTP 启动、健康检查、systemd/Gunicorn 和环境变量配置
- 明确 Java 与 Python 虽可通过 HTTP 分离部署，但当前仍需共享 MRI 文件路径

## 接口示例

```http
POST http://127.0.0.1:50007/segment
Content-Type: application/json

{
  "modelPath": "/opt/brainu/models/best_epoch.pth",
  "filePath": "/var/lib/brainu/uploads/case-001",
  "modelName": "Multi-modal U-Net模型"
}
```

```json
{
  "imagePath": "resultEnv/xxxx"
}
```

## 验证

- `python_server/server.py` Python 语法检查通过
- `pom.xml` XML 结构检查通过
- `git diff --check` 通过
- 旧 `new Socket`、`getSocketServerMsg`、`import socket`、`end send` 引用为 0

当前执行环境没有 Maven，且 Maven Wrapper 无法访问 Maven Central，因此未能在此环境完成 Java 全量构建。合并前建议 CI 或本机执行：

```bash
cd designSystem/BrainU-backend
mvn clean package -DskipTests
```

## 配置说明

本 PR 没有重新提交现有 `application.yml`，因为该文件包含疑似真实的历史连接凭据。`BrainUAiProperties` 已提供 `http://127.0.0.1:50007` 等默认值；生产环境应使用 `application-local.yml` 或环境变量配置，并立即轮换仓库历史中出现过的凭据。